### PR TITLE
Add scrolling and zooming to arrange view

### DIFF
--- a/src/main/Constants.ts
+++ b/src/main/Constants.ts
@@ -76,3 +76,5 @@ export const Layout = {
 }
 
 export const MaxNoteNumber = 127
+
+export const WHEEL_SCROLL_RATE = 1 / 120

--- a/src/main/components/PianoRoll/PianoRoll.tsx
+++ b/src/main/components/PianoRoll/PianoRoll.tsx
@@ -102,6 +102,7 @@ const PianoRollWrapper: FC = observer(() => {
   const s = rootStore.pianoRollStore
   const {
     scaleX,
+    scaleY,
     scrollLeft,
     scrollTop,
     transform,
@@ -127,11 +128,11 @@ const PianoRollWrapper: FC = observer(() => {
 
   const onClickScaleUpVertical = useCallback(
     () => s.scaleAroundPointY(0.2, 0),
-    [scaleX, s]
+    [scaleY, s]
   )
   const onClickScaleDownVertical = useCallback(
     () => s.scaleAroundPointY(-0.2, 0),
-    [scaleX, s]
+    [scaleY, s]
   )
   const onClickScaleResetVertical = useCallback(() => (s.scaleY = 1), [s])
 
@@ -139,11 +140,11 @@ const PianoRollWrapper: FC = observer(() => {
     (e: React.WheelEvent) => {
       if (e.shiftKey && (e.altKey || e.ctrlKey)) {
         // vertical zoom
-        let scaleXDelta = isTouchPadEvent(e.nativeEvent)
+        let scaleYDelta = isTouchPadEvent(e.nativeEvent)
           ? 0.02 * e.deltaY
           : 0.01 * e.deltaX
-        scaleXDelta = clamp(scaleXDelta, -0.15, 0.15) // prevent acceleration to zoom too fast
-        s.scaleAroundPointY(scaleXDelta, e.nativeEvent.offsetY)
+        scaleYDelta = clamp(scaleYDelta, -0.15, 0.15) // prevent acceleration to zoom too fast
+        s.scaleAroundPointY(scaleYDelta, e.nativeEvent.offsetY)
       } else if (e.altKey || e.ctrlKey) {
         // horizontal zoom
         const scaleFactor = isTouchPadEvent(e.nativeEvent) ? 0.01 : -0.01

--- a/src/main/components/PianoRoll/PianoRoll.tsx
+++ b/src/main/components/PianoRoll/PianoRoll.tsx
@@ -4,7 +4,7 @@ import { observer } from "mobx-react-lite"
 import { FC, useCallback, useRef } from "react"
 import SplitPane from "react-split-pane"
 import styled from "styled-components"
-import { Layout } from "../../Constants"
+import { Layout, WHEEL_SCROLL_RATE } from "../../Constants"
 import { isTouchPadEvent } from "../../helpers/touchpad"
 import { useStores } from "../../hooks/useStores"
 import ControlPane from "../ControlPane/ControlPane"
@@ -14,8 +14,6 @@ import {
   VerticalScaleScrollBar,
 } from "../inputs/ScaleScrollBar"
 import { PianoRollStage } from "./PianoRollStage"
-
-const WHEEL_SCROLL_RATE = 1 / 120
 
 const Parent = styled.div`
   flex-grow: 1;


### PR DESCRIPTION
This PR makes it possible to do this on the arrange view
- scroll horizontally with two finger horizontal movement on trackpad (at least on macOS)
- zoom horizontally with pinch to zoom (mac) or `ctlr` / `alt` + `mouseWheel`
- zoom vertically with `shift` + `ctlr` / `alt` + `mouseWheel`

Vertical zooming button are also added to the vertical scroll bar