### PR TITLE
Add shortcuts for rewind/forward, next/prev track and solo/mute/ghost

### DIFF
--- a/src/main/actions/player.ts
+++ b/src/main/actions/player.ts
@@ -98,6 +98,41 @@ export const previousTrack = (rootStore: RootStore) => () => {
   const { song } = rootStore
   song.selectTrack(Math.max(song.selectedTrackId - 1, 1))
 }
+
+export const toggleSolo = (rootStore: RootStore) => () => {
+  const {
+    song: { selectedTrackId },
+    trackMute,
+  } = rootStore
+  if (trackMute.isSolo(selectedTrackId)) {
+    trackMute.unsolo(selectedTrackId)
+  } else {
+    trackMute.solo(selectedTrackId)
+  }
+}
+
+export const toggleMute = (rootStore: RootStore) => () => {
+  const {
+    song: { selectedTrackId },
+    trackMute,
+  } = rootStore
+  if (trackMute.isMuted(selectedTrackId)) {
+    trackMute.unmute(selectedTrackId)
+  } else {
+    trackMute.mute(selectedTrackId)
+  }
+}
+
+export const toggleGhost = (RootStore: RootStore) => () => {
+  const {
+    song: { selectedTrackId },
+    pianoRollStore,
+  } = RootStore
+  if (pianoRollStore.notGhostTracks.has(selectedTrackId)) {
+    pianoRollStore.notGhostTracks.delete(selectedTrackId)
+  } else {
+    pianoRollStore.notGhostTracks.add(selectedTrackId)
+  }
 }
 
 export const previewNote =

--- a/src/main/actions/player.ts
+++ b/src/main/actions/player.ts
@@ -88,6 +88,16 @@ export const fastForwardOneBar = (rootStore: RootStore) => () => {
     pianoRollStore.setScrollLeftInPixels(x - pianoRollStore.canvasWidth * 0.7)
   }
 }
+
+export const nextTrack = (rootStore: RootStore) => () => {
+  const { song } = rootStore
+  song.selectTrack(Math.min(song.selectedTrackId + 1, song.tracks.length - 1))
+}
+
+export const previousTrack = (rootStore: RootStore) => () => {
+  const { song } = rootStore
+  song.selectTrack(Math.max(song.selectedTrackId - 1, 1))
+}
 }
 
 export const previewNote =

--- a/src/main/actions/player.ts
+++ b/src/main/actions/player.ts
@@ -1,7 +1,7 @@
 import { isNoteEvent } from "../../common/track/identify"
 import RootStore from "../stores/RootStore"
 
-export const play = (rootStore: RootStore) => () => {
+export const playOrPause = (rootStore: RootStore) => () => {
   const {
     services: { player },
   } = rootStore
@@ -15,13 +15,11 @@ export const play = (rootStore: RootStore) => () => {
 export const stop = (rootStore: RootStore) => () => {
   const {
     services: { player },
+    pianoRollStore,
   } = rootStore
-  if (player.isPlaying) {
-    player.stop()
-  } else {
-    player.stop()
-    player.position = 0
-  }
+  player.stop()
+  player.position = 0
+  pianoRollStore.setScrollLeftInTicks(0)
 }
 
 const defaultTimeSignature = {

--- a/src/main/components/Help/HelpDialog.tsx
+++ b/src/main/components/Help/HelpDialog.tsx
@@ -71,7 +71,10 @@ export const HelpDialog: FC = observer(() => {
         </DialogContentText>
         <HotKey
           hotKeys={[["Space"]]}
-          text={localized("play-pause", "Play/Pause")}
+          text={localized("play-pause", "Play / Pause")}
+        />
+        <HotKey hotKeys={[["Enter"]]} text={localized("stop", "Stop")} />
+        <HotKey
         />
         <HotKey
           hotKeys={[["1"]]}

--- a/src/main/components/Help/HelpDialog.tsx
+++ b/src/main/components/Help/HelpDialog.tsx
@@ -75,6 +75,9 @@ export const HelpDialog: FC = observer(() => {
         />
         <HotKey hotKeys={[["Enter"]]} text={localized("stop", "Stop")} />
         <HotKey
+          hotKeys={[["A"], ["D"]]}
+          text={localized("forward-rewind", "Rewind / Forward")}
+        />
         />
         <HotKey
           hotKeys={[["1"]]}

--- a/src/main/components/Help/HelpDialog.tsx
+++ b/src/main/components/Help/HelpDialog.tsx
@@ -78,6 +78,10 @@ export const HelpDialog: FC = observer(() => {
           hotKeys={[["A"], ["D"]]}
           text={localized("forward-rewind", "Rewind / Forward")}
         />
+        <HotKey
+          hotKeys={[["S"], ["W"]]}
+          text={localized("next-previous", "Next / Previous Track")}
+        />
         />
         <HotKey
           hotKeys={[["1"]]}

--- a/src/main/components/Help/HelpDialog.tsx
+++ b/src/main/components/Help/HelpDialog.tsx
@@ -82,6 +82,9 @@ export const HelpDialog: FC = observer(() => {
           hotKeys={[["S"], ["W"]]}
           text={localized("next-previous", "Next / Previous Track")}
         />
+        <HotKey
+          hotKeys={[["N"], ["M"], [","]]}
+          text={localized("solo-mute-ghost", "Solo, Mute or Ghost Track")}
         />
         <HotKey
           hotKeys={[["1"]]}

--- a/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
+++ b/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
@@ -52,6 +52,14 @@ export const GlobalKeyboardShortcut: FC = () => {
           stop(rootStore)()
           break
         }
+        case "KeyA": {
+          rewindOneBar(rootStore)()
+          return
+        }
+        case "KeyD": {
+          fastForwardOneBar(rootStore)()
+          return
+        }
         }
         default:
           // do not call preventDefault

--- a/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
+++ b/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
@@ -46,6 +46,12 @@ export const GlobalKeyboardShortcut: FC = () => {
           if (e.shiftKey) {
             rootStore.rootViewStore.openHelp = true
           }
+          break
+        }
+        case "Enter": {
+          stop(rootStore)()
+          break
+        }
         }
         default:
           // do not call preventDefault

--- a/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
+++ b/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
@@ -60,6 +60,14 @@ export const GlobalKeyboardShortcut: FC = () => {
           fastForwardOneBar(rootStore)()
           return
         }
+        case "KeyS": {
+          nextTrack(rootStore)()
+          return
+        }
+        case "KeyW": {
+          previousTrack(rootStore)()
+          return
+        }
         }
         default:
           // do not call preventDefault

--- a/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
+++ b/src/main/components/KeyboardShortcut/GlobalKeyboardShortcut.tsx
@@ -1,5 +1,15 @@
 import { FC, useEffect } from "react"
-import { play, stop } from "../../actions"
+import {
+  fastForwardOneBar,
+  nextTrack,
+  playOrPause,
+  previousTrack,
+  rewindOneBar,
+  stop,
+  toggleGhost,
+  toggleMute,
+  toggleSolo,
+} from "../../actions"
 import { redo, undo } from "../../actions/history"
 import { useStores } from "../../hooks/useStores"
 import { isFocusable } from "./isFocusable"
@@ -18,11 +28,7 @@ export const GlobalKeyboardShortcut: FC = () => {
       }
       switch (e.code) {
         case "Space": {
-          if (player.isPlaying) {
-            stop(rootStore)()
-          } else {
-            play(rootStore)()
-          }
+          playOrPause(rootStore)()
           break
         }
         case "KeyZ": {
@@ -68,6 +74,17 @@ export const GlobalKeyboardShortcut: FC = () => {
           previousTrack(rootStore)()
           return
         }
+        case "KeyN": {
+          toggleSolo(rootStore)()
+          return
+        }
+        case "KeyM": {
+          toggleMute(rootStore)()
+          return
+        }
+        case "Comma": {
+          toggleGhost(rootStore)()
+          return
         }
         default:
           // do not call preventDefault

--- a/src/main/components/TransportPanel/TransportPanel.tsx
+++ b/src/main/components/TransportPanel/TransportPanel.tsx
@@ -19,7 +19,7 @@ import styled from "styled-components"
 import { localized } from "../../../common/localize/localizedString"
 import {
   fastForwardOneBar,
-  play,
+  playOrPause,
   rewindOneBar,
   stop,
   toggleEnableLoop,
@@ -192,7 +192,7 @@ export const TransportPanel: FC = observer(() => {
       .length > 0
   const isSynthLoading = rootStore.services.synth.isLoading
 
-  const onClickPlay = play(rootStore)
+  const onClickPlay = playOrPause(rootStore)
   const onClickStop = stop(rootStore)
   const onClickBackward = rewindOneBar(rootStore)
   const onClickForward = fastForwardOneBar(rootStore)


### PR DESCRIPTION
Title says it all. This PR adds some pratical shortcuts.

- `Enter` for stop and reset player (same shortcut as Lopic Pro X)
- `A` / `D` for rewind and forward player
- `S` / `W` for next and previous track (these four keys are chosen since they are very convinient when using a mouse with the right arm and should feel familiar for gamers)
- `N`, `M` and `,` for solo, mute and ghost track. The key `M` is chosen for mute. Since `S` is taken, I chose the keys next to it for solo and ghost. I think this should be fairly intuitive after looking at the track panel at the side (same order).

This PR also makes sure that the player in the rewind and forward should not go out of the screen. Likewise the player is reset when clicking on the stop button or with the `Enter` key (this should partially solve #142)

Any feedback is very welcome 😄