### PR TITLE
Don't quantize selection in time

### DIFF
--- a/src/main/actions/selection.ts
+++ b/src/main/actions/selection.ts
@@ -40,16 +40,12 @@ function eventsInSelection(events: TrackEvent[], selection: Selection) {
 
 export const resizeSelection =
   (rootStore: RootStore) => (start: NotePoint, end: NotePoint) => {
-    const {
-      pianoRollStore,
-      pianoRollStore: { quantizer },
-    } = rootStore
-
+    const { pianoRollStore } = rootStore
     pianoRollStore.selection = clampSelection(
       regularizedSelection(
-        quantizer.round(start.tick),
+        start.tick,
         start.noteNumber,
-        quantizer.round(end.tick),
+        end.tick,
         end.noteNumber
       )
     )


### PR DESCRIPTION
This is a change that's probably a bit subjective, but I found the current selection quantizer more annoying than helpful. If you for instance load a song with a lot of 8ths and 16ths notes it was quite annoying to change to global time snapping to just select some notes. AFAIK none of the DAW I've worked with have quantized the selection so I think this should familiar to most people 🥁