### PR TITLE
End note on mouse up and mouse drag

### DIFF
--- a/src/common/player/Player.ts
+++ b/src/common/player/Player.ts
@@ -204,6 +204,26 @@ export default class Player {
     )
   }
 
+  startNote({
+    channel,
+    noteNumber,
+    velocity,
+  }: Pick<NoteEvent, "noteNumber" | "velocity"> & {
+    channel: number
+  }) {
+    this._output.activate()
+    this.sendEvent(noteOnMidiEvent(0, channel, noteNumber, velocity))
+  }
+
+  stopNote({
+    channel,
+    noteNumber,
+  }: Pick<NoteEvent, "noteNumber"> & {
+    channel: number
+  }) {
+    this.sendEvent(noteOffMidiEvent(0, channel, noteNumber, 0))
+  }
+
   tickToMillisec(tick: number) {
     return (tick / (this.timebase / 60) / this._currentTempo) * 1000
   }

--- a/src/main/actions/track.ts
+++ b/src/main/actions/track.ts
@@ -203,12 +203,24 @@ export const createNote =
     }
     const added = selectedTrack.addEvent(note)
 
-    player.playNote({
+    player.startNote({
       ...note,
       channel: selectedTrack.channel,
     })
     return added
   }
+
+export const muteNote = (rootStore: RootStore) => (noteNumber: number) => {
+  const {
+    song,
+    services: { player },
+  } = rootStore
+  const selectedTrack = song.selectedTrack
+  if (selectedTrack === undefined || selectedTrack.channel == undefined) {
+    return
+  }
+  player.stopNote({ channel: selectedTrack.channel, noteNumber })
+}
 
 export type MoveNote = {
   id: number
@@ -240,7 +252,8 @@ export const moveNote = (rootStore: RootStore) => (params: MoveNote) => {
     })
 
     if (pitchChanged) {
-      player.playNote({
+      muteNote(rootStore)(note.noteNumber)
+      player.startNote({
         ...note,
         noteNumber: params.noteNumber,
         channel: selectedTrack.channel,

--- a/src/main/components/PianoRoll/MouseHandler/NoteMouseHandler.ts
+++ b/src/main/components/PianoRoll/MouseHandler/NoteMouseHandler.ts
@@ -2,6 +2,7 @@ import { observeDrag } from "../../../helpers/observeDrag"
 import RootStore from "../../../stores/RootStore"
 import {
   getPencilActionForMouseDown,
+  getPencilActionForMouseUp,
   getPencilCursorForMouseMove,
 } from "./PencilMouseHandler"
 import {
@@ -70,8 +71,13 @@ export default class NoteMouseHandler {
     }
   }
 
-  onMouseUp() {
+  onMouseUp(ev: React.MouseEvent) {
+    const e = ev.nativeEvent
     this.isMouseDown = false
+    switch (this.rootStore.pianoRollStore.mouseMode) {
+      case "pencil":
+        getPencilActionForMouseUp()(this.rootStore)(e)
+    }
   }
 }
 

--- a/src/main/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
+++ b/src/main/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
@@ -4,6 +4,7 @@ import {
   createNote,
   fixSelection,
   moveNote,
+  muteNote,
   previewNoteById,
   removeEvent,
   removeNoteFromSelection,
@@ -69,6 +70,10 @@ export const getPencilActionForMouseDown =
         return null
     }
   }
+
+export const getPencilActionForMouseUp = (): MouseGesture => {
+  return muteNoteAction
+}
 
 export const getPencilCursorForMouseMove =
   (rootStore: RootStore) =>
@@ -221,6 +226,14 @@ const createNoteAction: MouseGesture = (rootStore) => (e) => {
       })
     },
   })
+}
+
+const muteNoteAction: MouseGesture = (rootStore) => (e) => {
+  const { transform } = rootStore.pianoRollStore
+  const local = rootStore.pianoRollStore.getLocal(e)
+
+  const { noteNumber } = transform.getNotePoint(local)
+  muteNote(rootStore)(noteNumber)
 }
 
 const removeNoteAction: MouseGesture = (rootStore) => (e) => {


### PR DESCRIPTION
This is the aspect of Signal I've most wanted to change from the first time I used it. In current main branch if you create a long note (say one bar) and drag it, the overlapping notes played is not very pleasant to listen to. Likewise if you create melodies or chords with many long notes, it is quite tiresome to listen to the note until it ends.

As usual, feedback or just fixing up things I've forgot / done wrong is very much appreciated 😄

I once again want to say that this project is AMAZING! I've looked for something like this at least a year before I found it and it is of much higher technical quality that I could ever have dreamed of 💯 Still don't think that many people know about it and that is a shame. You have truly done a great job so far, @ryohey 🙏

Edit: After playing a bit more with this branch I notice the note doesn't always stop to play. It only happens some times and you can stop the note by clicking on the selected note. A similar issue can happen when you mute a track while playing