### PR TITLE
Fix hot key

### DIFF
--- a/src/main/components/KeyboardShortcut/PianoRollKeyboardShortcut.tsx
+++ b/src/main/components/KeyboardShortcut/PianoRollKeyboardShortcut.tsx
@@ -39,6 +39,7 @@ export const PianoRollKeyboardShortcut: FC = () => {
           return
       }
       e.preventDefault()
+      e.stopPropagation()
     }
 
     // Handle pasting here to allow pasting even when the element does not have focus, such as after clicking the ruler


### PR DESCRIPTION
There was a problem where Ctrl + D would perform duplicate notes and advance the cursor at the same time.
Added stopPropagation to perform only one keyboard shortcut at a time.