### PR TITLE
Re-added select all command key shortcut

### DIFF
--- a/src/main/components/KeyboardShortcut/pianoNotesKeyboardShortcutActions.tsx
+++ b/src/main/components/KeyboardShortcut/pianoNotesKeyboardShortcutActions.tsx
@@ -5,6 +5,7 @@ import {
   pasteSelection,
   quantizeSelectedNotes,
   resetSelection,
+  selectAllNotes,
   selectNextNote,
   selectPreviousNote,
   transposeSelection,
@@ -37,6 +38,11 @@ export const pianoNotesKeyboardShortcutActions = (
     code: "KeyD",
     metaKey: true,
     run: duplicateSelection(rootStore),
+  },
+  {
+    code: "KeyA",
+    metaKey: true,
+    run: selectAllNotes(rootStore),
   },
   {
     code: "KeyQ",


### PR DESCRIPTION
As mentioned on Gitter, the select-all key shortcut seem to have been removed during the refactoring in #179, so I've re-added here.