### PR TITLE
Reset end of track event after note deletion

### DIFF
--- a/src/common/track/Track.test.ts
+++ b/src/common/track/Track.test.ts
@@ -1,6 +1,7 @@
 import { deserialize, serialize } from "serializr"
 import Track from "./Track"
 import { NoteEvent } from "./TrackEvent"
+import { emptyTrack } from "./TrackFactory"
 
 describe("Track", () => {
   it("should be serializable", () => {
@@ -20,5 +21,19 @@ describe("Track", () => {
     expect(t.endOfTrack).toBe(track.endOfTrack)
     expect(t.events.length).toBe(1)
     expect(t.events[0].tick).toBe(123)
+  })
+  it("should reset end of track after note deletion", () => {
+    const track = emptyTrack(5)
+    const noteEvent = track.addEvent<NoteEvent>({
+      type: "channel",
+      subtype: "note",
+      duration: 120,
+      tick: 123,
+      velocity: 100,
+      noteNumber: 100,
+    })
+    expect(track.endOfTrack).toBe(243)
+    track.removeEvent(noteEvent.id)
+    expect(track.endOfTrack).toBe(0)
   })
 })

--- a/src/common/track/Track.ts
+++ b/src/common/track/Track.ts
@@ -13,7 +13,11 @@ import { pojo } from "../helpers/pojo"
 import { localized } from "../localize/localizedString"
 import { getInstrumentName } from "../midi/GM"
 import { programChangeMidiEvent, trackNameMidiEvent } from "../midi/MidiEvent"
-import { isControllerEventWithType, isNoteEvent } from "./identify"
+import {
+  isControllerEventWithType,
+  isEndOfTrackEvent,
+  isNoteEvent,
+} from "./identify"
 import {
   getEndOfTrackEvent,
   getLast,
@@ -157,12 +161,14 @@ export default class Track {
 
   updateEndOfTrack() {
     const tick = Math.max(
-      ...this.events.map((e) => {
-        if (isNoteEvent(e)) {
-          return e.tick + e.duration
-        }
-        return e.tick
-      })
+      ...this.events
+        .filter((e) => !isEndOfTrackEvent(e))
+        .map((e) => {
+          if (isNoteEvent(e)) {
+            return e.tick + e.duration
+          }
+          return e.tick
+        })
     )
     this.setEndOfTrack(tick)
   }


### PR DESCRIPTION
Previously, an end of track event counted as an event.
Therefore after deleting the last note, the end of track
was never set earlier.