### PR TITLE
Treat sentry errors as warnings

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -51,6 +51,9 @@ module.exports = merge(common, {
       ],
       dryRun: process.env.VERCEL_ENV !== "production",
       debug: true,
+      errorHandler: (err, invokeErr, compilation) => {
+        compilation.warnings.push("Sentry CLI Plugin: " + err.message)
+      },
     }),
   ],
 })


### PR DESCRIPTION
It seems that it failed to upload the artifact to Sentry because the free quota was exceeded.