### PR TITLE
Fix #237: Specify dist/ directory in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,10 @@
 {
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ],
   "cleanUrls": true
 }


### PR DESCRIPTION
Right now, if someone tries to push this repo on Vercel, they hit a blank screen after clicking "Launch" (see #237). That's because by default Vercel serves production from public/ directory, so by default the entire Webpack machinery will be ignored. I suspect it works on signal.vercel.app because it's overriden on Settings -> General -> Build & Development Settings. Without this fix other users will hit the same issue when trying to deploy their clone of the app.
