### PR TITLE
Filter event list to reflect the piano roll selection.

### DIFF
--- a/src/main/components/EventEditor/EventList.tsx
+++ b/src/main/components/EventEditor/EventList.tsx
@@ -14,22 +14,21 @@ const Container = styled.div`
   width: 100%;
   height: 100%;
 `
-  
+
 const EventList: FC = observer(() => {
   const rootStore = useStores()
   const {
-    pianoRollStore: { selectedTrack , selectedNoteIds: selectedEventIds = [] },
+    pianoRollStore: { selectedTrack, selectedNoteIds: selectedEventIds = [] },
   } = rootStore
 
+  const events = useMemo(() => {
+    const { events = [] } = selectedTrack || {}
+    if (selectedEventIds.length > 0) {
+      return events.filter((event) => selectedEventIds.indexOf(event.id) >= 0)
+    }
+    return events
+  }, [selectedTrack?.events, selectedEventIds])
 
-  const events = useMemo(()=>{
-    const { events = [] } = selectedTrack || {};
-    if( selectedEventIds.length > 0 ){
-      return events.filter(event => selectedEventIds.indexOf(event.id) >= 0);
-    } 
-    return events;
-  }, [selectedTrack?.events, selectedEventIds ]);
-  
   const ref = useRef<HTMLDivElement>(null)
   const size = useComponentSize(ref)
 


### PR DESCRIPTION
Filter the event list to the current selection when present.
[Screencast from 2023-09-06 15-17-17.webm](https://github.com/ryohey/signal/assets/2642857/d3caefa7-fc33-49f5-9046-c590a27411fb)
