### PR TITLE
Allow scrolling past the playhead while the song is playing

### DIFF
--- a/src/main/components/PianoRollToolbar/PianoRollToolbar.tsx
+++ b/src/main/components/PianoRollToolbar/PianoRollToolbar.tsx
@@ -33,10 +33,9 @@ export const PianoRollToolbar: FC = observer(() => {
     selectedTrackId,
   } = pianoRollStore
 
-  const onClickAutoScroll = useCallback(
-    () => (pianoRollStore.autoScroll = !pianoRollStore.autoScroll),
-    [pianoRollStore],
-  )
+  const onClickAutoScroll = useCallback(() => {
+    pianoRollStore.autoScroll = !pianoRollStore.autoScroll
+  }, [pianoRollStore])
 
   const onSelectQuantize = useCallback(
     (denominator: number) => {

--- a/src/main/components/TempoGraph/TempoGraph.tsx
+++ b/src/main/components/TempoGraph/TempoGraph.tsx
@@ -5,8 +5,8 @@ import { FC, useCallback, useEffect, useRef } from "react"
 import { Layout } from "../../Constants"
 import { useStores } from "../../hooks/useStores"
 import { useTheme } from "../../hooks/useTheme"
-import { BAR_WIDTH, HorizontalScrollBar } from "../inputs/ScrollBar"
 import CanvasPianoRuler from "../PianoRoll/CanvasPianoRuler"
+import { BAR_WIDTH, HorizontalScrollBar } from "../inputs/ScrollBar"
 import { TempoGraphAxis } from "./TempoGraphAxis"
 import { TempoGraphCanvas } from "./TempoGraphCanvas/TempoGraphCanvas"
 
@@ -26,10 +26,6 @@ export const TempoGraph: FC = observer(() => {
   const ref = useRef(null)
   const size = useComponentSize(ref)
 
-  const setScrollLeft = useCallback(
-    (x: number) => (tempoEditorStore.scrollLeft = x),
-    [],
-  )
   const theme = useTheme()
 
   const scrollLeft = Math.floor(_scrollLeft)
@@ -73,7 +69,10 @@ export const TempoGraph: FC = observer(() => {
       <HorizontalScrollBar
         scrollOffset={scrollLeft}
         contentLength={contentWidth}
-        onScroll={setScrollLeft}
+        onScroll={useCallback(
+          (v: any) => tempoEditorStore.setScrollLeft(v),
+          [tempoEditorStore],
+        )}
       />
     </Wrapper>
   )

--- a/src/main/components/TempoGraph/TempoGraphToolbar.tsx
+++ b/src/main/components/TempoGraph/TempoGraphToolbar.tsx
@@ -5,8 +5,8 @@ import { Localized } from "../../../components/Localized"
 import { useStores } from "../../hooks/useStores"
 import { AutoScrollButton } from "../Toolbar/AutoScrollButton"
 import QuantizeSelector from "../Toolbar/QuantizeSelector/QuantizeSelector"
-import { Toolbar } from "../Toolbar/Toolbar"
 import { ToolSelector } from "../Toolbar/ToolSelector"
+import { Toolbar } from "../Toolbar/Toolbar"
 
 const Title = styled.span`
   font-weight: bold;

--- a/src/main/stores/ArrangeViewStore.ts
+++ b/src/main/stores/ArrangeViewStore.ts
@@ -57,6 +57,7 @@ export default class ArrangeViewStore {
       scrollLeft: computed,
       transform: computed,
       trackTransform: computed,
+      playheadInScrollZone: computed,
       notes: computed,
       cursorX: computed,
       trackHeight: computed,
@@ -69,17 +70,13 @@ export default class ArrangeViewStore {
     })
   }
 
-  // keep scroll position to cursor
   setUpAutorun() {
+    // keep scroll position to cursor
     autorun(() => {
       const { isPlaying, position } = this.rootStore.player
-      const { scrollLeft, transform, canvasWidth } = this
-      if (this.autoScroll && isPlaying) {
-        const x = transform.getX(position)
-        const screenX = x - scrollLeft
-        if (screenX > canvasWidth * 0.7 || screenX < 0) {
-          this.scrollLeftTicks = position
-        }
+      const { autoScroll, playheadInScrollZone } = this
+      if (autoScroll && isPlaying && playheadInScrollZone) {
+        this.scrollLeftTicks = position
       }
     })
   }
@@ -105,6 +102,9 @@ export default class ArrangeViewStore {
     const maxOffset = Math.max(0, contentWidth - canvasWidth)
     const scrollLeft = Math.floor(Math.min(maxOffset, Math.max(0, x)))
     this.scrollLeftTicks = this.transform.getTicks(scrollLeft)
+    if (this.playheadInScrollZone) {
+      this.autoScroll = false
+    }
   }
 
   setScrollTop(value: number) {
@@ -168,6 +168,19 @@ export default class ArrangeViewStore {
     return (
       Math.ceil(transform.pixelsPerKey * transform.numberOfKeys) +
       bottomBorderWidth
+    )
+  }
+
+  get playheadPosition(): number {
+    const position = this.rootStore.player.position
+    return this.transform.getX(position - this.scrollLeftTicks)
+  }
+
+  // Returns true if the user needs to scroll to comfortably view the playhead.
+  get playheadInScrollZone(): boolean {
+    return (
+      this.playheadPosition < 0 ||
+      this.playheadPosition > this.canvasWidth * 0.7
     )
   }
 

--- a/src/main/stores/PianoRollStore.ts
+++ b/src/main/stores/PianoRollStore.ts
@@ -95,6 +95,7 @@ export default class PianoRollStore {
       scrollLeft: computed,
       scrollTop: computed,
       transform: computed,
+      playheadInScrollZone: computed,
       windowedEvents: computed,
       allNotes: computed,
       notes: computed,
@@ -121,14 +122,9 @@ export default class PianoRollStore {
   setUpAutorun() {
     autorun(() => {
       const { isPlaying, position } = this.rootStore.player
-      const { autoScroll, scrollLeftTicks, transform, canvasWidth } = this
-
-      // keep scroll position to cursor
-      if (autoScroll && isPlaying) {
-        const screenX = transform.getX(position - scrollLeftTicks)
-        if (screenX > canvasWidth * 0.7 || screenX < 0) {
-          this.scrollLeftTicks = position
-        }
+      const { autoScroll, playheadInScrollZone } = this
+      if (autoScroll && isPlaying && playheadInScrollZone) {
+        this.scrollLeftTicks = position
       }
     })
 
@@ -178,6 +174,9 @@ export default class PianoRollStore {
     const maxX = contentWidth - canvasWidth
     const scrollLeft = clamp(x, 0, maxX)
     this.scrollLeftTicks = this.transform.getTicks(scrollLeft)
+    if (this.playheadInScrollZone) {
+      this.autoScroll = false
+    }
   }
 
   setScrollTopInPixels(y: number) {
@@ -242,6 +241,19 @@ export default class PianoRollStore {
       Layout.pixelsPerTick * this.scaleX,
       Layout.keyHeight * this.scaleY,
       127,
+    )
+  }
+
+  get playheadPosition(): number {
+    const position = this.rootStore.player.position
+    return this.transform.getX(position - this.scrollLeftTicks)
+  }
+
+  // Returns true if the user needs to scroll to comfortably view the playhead.
+  get playheadInScrollZone(): boolean {
+    return (
+      this.playheadPosition < 0 ||
+      this.playheadPosition > this.canvasWidth * 0.7
     )
   }
 

--- a/src/main/stores/TempoEditorStore.ts
+++ b/src/main/stores/TempoEditorStore.ts
@@ -44,6 +44,7 @@ export default class TempoEditorStore {
       transform: computed,
       items: computed,
       cursorX: computed,
+      curPlayheadScreenOffset: computed,
       contentWidth: computed,
       controlPoints: computed,
       selectionRect: computed,
@@ -96,8 +97,8 @@ export default class TempoEditorStore {
   }
 
   // Returns true if the user needs to scroll to comfortably view the playhead.
-  playheadInScrollZone(playheadPos: number): boolean {
-    return playheadPos < 0 || playheadPos > this.canvasWidth * 0.7
+  playheadInScrollZone(playheadOffset: number): boolean {
+    return playheadOffset < 0 || playheadOffset > this.canvasWidth * 0.7
   }
 
   get items() {

--- a/src/main/stores/TempoEditorStore.ts
+++ b/src/main/stores/TempoEditorStore.ts
@@ -51,19 +51,27 @@ export default class TempoEditorStore {
   }
 
   setUpAutorun() {
+    // keep scroll position to cursor
     autorun(() => {
       const { isPlaying, position } = this.rootStore.player
-      const { autoScroll, scrollLeft, transform, canvasWidth } = this
+      const { autoScroll, transform, curPlayheadScreenOffset } = this
 
-      // keep scroll position to cursor
-      if (autoScroll && isPlaying) {
-        const x = transform.getX(position)
-        const screenX = x - scrollLeft
-        if (screenX > canvasWidth * 0.7 || screenX < 0) {
-          this.scrollLeft = x
-        }
+      if (
+        isPlaying &&
+        autoScroll &&
+        this.playheadInScrollZone(curPlayheadScreenOffset)
+      ) {
+        this.scrollLeft = transform.getX(position)
       }
     })
+  }
+
+  setScrollLeft(x: number) {
+    const nextPlayheadPos = this.playheadScreenOffset(x)
+    if (this.playheadInScrollZone(nextPlayheadPos)) {
+      this.autoScroll = false
+    }
+    this.scrollLeft = x
   }
 
   get transform() {
@@ -73,6 +81,23 @@ export default class TempoEditorStore {
 
   get cursorX(): number {
     return this.transform.getX(this.rootStore.player.position)
+  }
+
+  // Position of the playhead relative to the current screen.
+  get curPlayheadScreenOffset(): number {
+    return this.playheadScreenOffset(this.scrollLeft)
+  }
+
+  // Position of the playhead relative to a screen. `scrollLeft` is the position
+  // in the song where the screen starts.
+  playheadScreenOffset(scrollLeft: number): number {
+    const position = this.rootStore.player.position
+    return this.transform.getX(position) - scrollLeft
+  }
+
+  // Returns true if the user needs to scroll to comfortably view the playhead.
+  playheadInScrollZone(playheadPos: number): boolean {
+    return playheadPos < 0 || playheadPos > this.canvasWidth * 0.7
   }
 
   get items() {


### PR DESCRIPTION
Before this change, the editor prevented you from scrolling the playhead off-screen if `autoScroll` was enabled and the song was playing. Now you can scroll as far as you want while the song is playing.

If you scroll sufficiently far, `autoScroll` will become unset. You can jump back to the current playhead position by turning `autoScroll` back on.