### PR TITLE
Fix #382 - correct Piano Roll horizontal scroll bar behavior

### DIFF
--- a/app/src/stores/PianoRollStore.ts
+++ b/app/src/stores/PianoRollStore.ts
@@ -164,7 +164,7 @@ export default class PianoRollStore {
     const startTick = transform.getTick(scrollLeft)
     const widthTick = transform.getTick(canvasWidth)
     const endTick = startTick + widthTick
-    return transform.getTick(Math.max(trackEndTick, endTick))
+    return transform.getX(Math.max(trackEndTick, endTick))
   }
 
   get contentHeight(): number {


### PR DESCRIPTION
Some code was converting a tick value into a tick again. Corrected it to convert ticks to pixels.