### PR TITLE
Disable auto-scrolling when the user manually scrolls

### DIFF
--- a/app/src/components/ArrangeView/ArrangeView.tsx
+++ b/app/src/components/ArrangeView/ArrangeView.tsx
@@ -99,10 +99,10 @@ export const ArrangeView: FC = observer(() => {
   const ref = useRef(null)
   const size = useComponentSize(ref)
 
-  const setScrollLeft = useCallback(
-    (v: number) => arrangeViewStore.setScrollLeftInPixels(v),
-    [],
-  )
+  const setScrollLeft = useCallback((v: number) => {
+    arrangeViewStore.setScrollLeftInPixels(v)
+    arrangeViewStore.autoScroll = false
+  }, [])
   const setScrollTop = useCallback(
     (v: number) => arrangeViewStore.setScrollTop(v),
     [],

--- a/app/src/components/ArrangeView/ArrangeViewCanvas/ArrangeViewCanvas.tsx
+++ b/app/src/components/ArrangeView/ArrangeViewCanvas/ArrangeViewCanvas.tsx
@@ -55,10 +55,10 @@ export const ArrangeViewCanvas: FC<ArrangeViewCanvasProps> = observer(
       [scrollLeft, scrollTop],
     )
 
-    const setScrollLeft = useCallback(
-      (v: number) => arrangeViewStore.setScrollLeftInPixels(v),
-      [],
-    )
+    const setScrollLeft = useCallback((v: number) => {
+      arrangeViewStore.setScrollLeftInPixels(v)
+      arrangeViewStore.autoScroll = false
+    }, [])
     const setScrollTop = useCallback(
       (v: number) => arrangeViewStore.setScrollTop(v),
       [],

--- a/app/src/components/PianoRoll/MouseHandler/NoteMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/NoteMouseHandler.ts
@@ -81,6 +81,7 @@ const dragScrollAction: MouseGesture =
     observeDrag({
       onMouseMove: (e: MouseEvent) => {
         pianoRollStore.scrollBy(e.movementX, e.movementY)
+        pianoRollStore.autoScroll = false
       },
     })
   }

--- a/app/src/components/PianoRoll/PianoRoll.tsx
+++ b/app/src/components/PianoRoll/PianoRoll.tsx
@@ -123,7 +123,13 @@ const PianoRollWrapper: FC = observer(() => {
       <HorizontalScaleScrollBar
         scrollOffset={scrollLeft}
         contentLength={contentWidth}
-        onScroll={useCallback((v: any) => s.setScrollLeftInPixels(v), [s])}
+        onScroll={useCallback(
+          (v: any) => {
+            s.setScrollLeftInPixels(v)
+            s.autoScroll = false
+          },
+          [s],
+        )}
         onClickScaleUp={onClickScaleUpHorizontal}
         onClickScaleDown={onClickScaleDownHorizontal}
         onClickScaleReset={onClickScaleResetHorizontal}

--- a/app/src/components/TempoGraph/TempoGraph.tsx
+++ b/app/src/components/TempoGraph/TempoGraph.tsx
@@ -27,7 +27,7 @@ export const TempoGraph: FC = observer(() => {
   const size = useComponentSize(ref)
 
   const setScrollLeft = useCallback((x: number) => {
-    tempoEditorStore.setScrollLeft(x)
+    tempoEditorStore.setScrollLeftInPixels(x)
     tempoEditorStore.autoScroll = false
   }, [])
   const theme = useTheme()

--- a/app/src/components/TempoGraph/TempoGraph.tsx
+++ b/app/src/components/TempoGraph/TempoGraph.tsx
@@ -27,7 +27,7 @@ export const TempoGraph: FC = observer(() => {
   const size = useComponentSize(ref)
 
   const setScrollLeft = useCallback(
-    (x: number) => (tempoEditorStore.scrollLeft = x),
+    (x: number) => tempoEditorStore.setScrollLeft(x),
     [],
   )
   const theme = useTheme()

--- a/app/src/components/TempoGraph/TempoGraph.tsx
+++ b/app/src/components/TempoGraph/TempoGraph.tsx
@@ -26,10 +26,10 @@ export const TempoGraph: FC = observer(() => {
   const ref = useRef(null)
   const size = useComponentSize(ref)
 
-  const setScrollLeft = useCallback(
-    (x: number) => tempoEditorStore.setScrollLeft(x),
-    [],
-  )
+  const setScrollLeft = useCallback((x: number) => {
+    tempoEditorStore.setScrollLeft(x)
+    tempoEditorStore.autoScroll = false
+  }, [])
   const theme = useTheme()
 
   const scrollLeft = Math.floor(_scrollLeft)

--- a/app/src/stores/ArrangeViewStore.ts
+++ b/app/src/stores/ArrangeViewStore.ts
@@ -104,9 +104,6 @@ export default class ArrangeViewStore {
     const maxOffset = Math.max(0, contentWidth - canvasWidth)
     const scrollLeft = Math.floor(Math.min(maxOffset, Math.max(0, x)))
     this.scrollLeftTicks = this.transform.getTick(scrollLeft)
-    if (this.playheadInScrollZone) {
-      this.autoScroll = false
-    }
   }
 
   setScrollTop(value: number) {

--- a/app/src/stores/PianoRollStore.ts
+++ b/app/src/stores/PianoRollStore.ts
@@ -189,9 +189,6 @@ export default class PianoRollStore {
     const maxX = contentWidth - canvasWidth
     const scrollLeft = clamp(x, 0, maxX)
     this.scrollLeftTicks = this.transform.getTick(scrollLeft)
-    if (this.playheadInScrollZone) {
-      this.autoScroll = false
-    }
   }
 
   setScrollTopInPixels(y: number) {

--- a/app/src/stores/TempoEditorStore.ts
+++ b/app/src/stores/TempoEditorStore.ts
@@ -64,10 +64,6 @@ export default class TempoEditorStore {
   }
 
   setScrollLeft(x: number) {
-    const nextPlayheadPos = this.playheadScreenOffset(x)
-    if (this.playheadInScrollZone(nextPlayheadPos)) {
-      this.autoScroll = false
-    }
     this.scrollLeft = x
   }
 

--- a/app/src/stores/TickScrollStore.ts
+++ b/app/src/stores/TickScrollStore.ts
@@ -1,0 +1,103 @@
+import { Player } from "@signal-app/player"
+import { clamp } from "lodash"
+import { autorun, computed, makeObservable } from "mobx"
+import { TickTransform } from "../entities/transform/TickTransform"
+import Song from "../song"
+
+interface TickScrollProvider {
+  readonly rootStore: { song: Song; player: Player }
+  readonly transform: TickTransform
+  readonly canvasWidth: number
+  readonly autoScroll: boolean
+  scrollLeftTicks: number
+  scaleX: number
+}
+
+// Store for scrolling according to the playback time
+export class TickScrollStore {
+  constructor(
+    private readonly parent: TickScrollProvider,
+    private readonly minScaleX: number,
+    private readonly maxScaleX: number,
+  ) {
+    makeObservable(this, {
+      scrollLeft: computed,
+      playheadPosition: computed,
+      playheadInScrollZone: computed,
+    })
+  }
+
+  get scrollLeft(): number {
+    return Math.round(this.parent.transform.getX(this.parent.scrollLeftTicks))
+  }
+
+  setUpAutoScroll() {
+    autorun(() => {
+      const {
+        autoScroll,
+        rootStore: { player },
+      } = this.parent
+      const { isPlaying, position } = player
+      const { playheadInScrollZone } = this
+      if (autoScroll && isPlaying && playheadInScrollZone) {
+        this.parent.scrollLeftTicks = position
+      }
+    })
+  }
+
+  setScrollLeftInPixels(x: number) {
+    const { contentWidth } = this
+    const { transform, canvasWidth } = this.parent
+    const maxX = contentWidth - canvasWidth
+    const scrollLeft = clamp(x, 0, maxX)
+    this.parent.scrollLeftTicks = transform.getTick(scrollLeft)
+  }
+
+  // Unlike scrollLeft = tick, this method keeps the scroll position within the content area
+  setScrollLeftInTicks(tick: number) {
+    this.setScrollLeftInPixels(this.parent.transform.getX(tick))
+  }
+
+  get contentWidth(): number {
+    const { transform, canvasWidth } = this.parent
+    const trackEndTick = this.parent.rootStore.song.endOfSong
+    const startTick = transform.getTick(this.scrollLeft)
+    const widthTick = transform.getTick(canvasWidth)
+    const endTick = startTick + widthTick
+    return transform.getX(Math.max(trackEndTick, endTick))
+  }
+
+  scaleAroundPointX(scaleXDelta: number, pixelX: number) {
+    const { maxScaleX, minScaleX } = this
+    const pixelXInTicks0 = this.parent.transform.getTick(
+      this.scrollLeft + pixelX,
+    )
+    this.parent.scaleX = clamp(
+      this.parent.scaleX * (1 + scaleXDelta),
+      minScaleX,
+      maxScaleX,
+    )
+    const pixelXInTicks1 = this.parent.transform.getTick(
+      this.scrollLeft + pixelX,
+    )
+    const scrollInTicks = pixelXInTicks1 - pixelXInTicks0
+    this.setScrollLeftInTicks(this.parent.scrollLeftTicks - scrollInTicks)
+  }
+
+  get playheadPosition(): number {
+    const {
+      transform,
+      scrollLeftTicks,
+      rootStore: { player },
+    } = this.parent
+    return transform.getX(player.position - scrollLeftTicks)
+  }
+
+  // Returns true if the user needs to scroll to comfortably view the playhead.
+  get playheadInScrollZone(): boolean {
+    const { canvasWidth } = this.parent
+    return (
+      this.playheadPosition < 0 || this.playheadPosition > canvasWidth * 0.7
+    )
+  }
+}


### PR DESCRIPTION
Enable scrolling beyond the playhead position as suggested in #354
Add `TickScroll` class to unify horizontal scroll handling in `TempoEditor`, `PianoRoll`, and `ArrangeView`