### PR TITLE
Fix npm build for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
+.aider*
+
 # Logs
 logs
 *.log
 npm-debug.log*
+
 
 # Runtime data
 pids

--- a/package-lock.json
+++ b/package-lock.json
@@ -5512,7 +5512,7 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/qs": {
       "version": "6.9.15",
@@ -5530,7 +5530,7 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5540,7 +5540,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "turbo run dev --parallel",
     "build": "npm run build:app && npm run build:static",
-    "build:app": "turbo build && cp -r app/dist dist",
-    "build:static": "npm install --prefix static && npm run build --prefix static && cp -r static/out/* dist",
+    "build:app": "turbo build && cpx \"app/dist/**/*\" dist",
+    "build:static": "npm install --prefix static && npm run build --prefix static && cpx \"static/out/**/*\" dist",
     "serve": "npx http-server dist",
     "test": "turbo test",
     "lint": "turbo lint",
@@ -14,7 +14,7 @@
     "firebase": "npm --prefix functions run build && firebase emulators:start",
     "firebase:deploy": "firebase deploy",
     "dev:electron": "concurrently \"npm run dev:electron -w app\" \"npm run dev --prefix electron\"",
-    "build:electron": "npm run build:electron -w app && rm -rf electron/dist_renderer && cp -r app/dist electron/dist_renderer",
+    "build:electron": "npm run build:electron -w app && rm -rf electron/dist_renderer && cpx \"app/dist/**/*\" electron/dist_renderer",
     "package:electron": "npm run build:electron && npm run package:darwin --prefix electron",
     "make:electron": "npm run build:electron && npm run make:mas --prefix electron",
     "make:darwin": "npm run build:electron && npm run make:darwin --prefix electron"
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/ryohey/signal/",
   "private": true,
   "devDependencies": {
+    "cpx": "^1.5.0",
     "prettier": "^3.2.5",
     "turbo": "^2.0.14"
   },


### PR DESCRIPTION
Simply replacing the `cp` command with cross-platform node module `cpx` to accommodate Windows users.

Resolves https://github.com/ryohey/signal/issues/397
