### PR TITLE
Fix note resizing behavior

### DIFF
--- a/app/src/actions/selection.ts
+++ b/app/src/actions/selection.ts
@@ -16,10 +16,10 @@ import { transposeNotes } from "./song"
 
 function eventsInSelection(events: TrackEvent[], selection: Selection) {
   const selectionRect = {
-    x: selection.from.tick,
-    width: selection.to.tick - selection.from.tick,
-    y: selection.to.noteNumber,
-    height: selection.from.noteNumber - selection.to.noteNumber,
+    x: selection.fromTick,
+    width: selection.toTick - selection.fromTick,
+    y: selection.toNoteNumber,
+    height: selection.fromNoteNumber - selection.toNoteNumber,
   }
   return events.filter(isNoteEvent).filter((b) =>
     Rect.intersects(
@@ -101,12 +101,7 @@ export const startSelection =
       pianoRollStore.selectedNoteIds = []
     }
 
-    // 選択範囲の右上を pos にする
-    // Set the upper right corner of the selection to POS
-    pianoRollStore.selection = {
-      from: point,
-      to: point,
-    }
+    pianoRollStore.selection = Selection.fromPoints(point, point)
   }
 
 export const resetSelection =
@@ -153,7 +148,7 @@ export const copySelection =
       .filter(isNoteEvent)
 
     const startTick =
-      selection?.from.tick ?? min(selectedNotes.map((note) => note.tick))!
+      selection?.fromTick ?? min(selectedNotes.map((note) => note.tick))!
 
     // 選択されたノートをコピー
     // Copy selected note
@@ -236,7 +231,7 @@ export const duplicateSelection =
     pushHistory()
 
     // move to the end of selection
-    let deltaTick = selection.to.tick - selection.from.tick
+    let deltaTick = selection.toTick - selection.fromTick
 
     const selectedNotes = selectedNoteIds
       .map((id) => selectedTrack.getEventById(id))

--- a/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
@@ -154,17 +154,17 @@ const dragNoteEdgeAction =
           noteId,
         })),
       {
-        onChange(_e, changes) {
+        onChange(_e, { oldPosition, newPosition }) {
           const newNote = selectedTrack.getEventById(noteId)
           if (newNote == undefined || !isNoteEvent(newNote)) {
             return
           }
           // save last note duration
-          if (changes.has("tick")) {
+          if (oldPosition.tick !== newPosition.tick) {
             pianoRollStore.lastNoteDuration = newNote.duration
           }
           if (
-            changes.has("noteNumber") &&
+            oldPosition.noteNumber !== newPosition.noteNumber &&
             newNote.noteNumber !== playingNoteNumber
           ) {
             stopNote(rootStore)({ noteNumber: playingNoteNumber, channel })

--- a/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
@@ -185,7 +185,6 @@ const dragNoteEdgeAction =
           }
         },
       },
-      "moveAlways",
     )(rootStore)(e)
   }
 

--- a/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
@@ -18,8 +18,6 @@ import { isNoteEvent } from "../../../track"
 import { moveDraggableAction } from "./moveDraggableAction"
 import { MouseGesture } from "./NoteMouseHandler"
 
-const MIN_DURATION = 10
-
 export const getPencilActionForMouseDown =
   (rootStore: RootStore) =>
   (e: MouseEvent): MouseGesture | null => {

--- a/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
@@ -128,7 +128,7 @@ const dragNoteEdgeAction =
   (e) => {
     const {
       pianoRollStore,
-      pianoRollStore: { selectedTrack, transform, selectedNoteIds, quantizer },
+      pianoRollStore: { selectedTrack, selectedNoteIds },
     } = rootStore
 
     if (selectedTrack === undefined || selectedTrack.channel === undefined) {

--- a/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
@@ -185,6 +185,7 @@ const dragNoteEdgeAction =
           }
         },
       },
+      "moveAlways",
     )(rootStore)(e)
   }
 

--- a/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/PencilMouseHandler.ts
@@ -56,7 +56,7 @@ export const getPencilActionForMouseDown =
             }
           }
         } else {
-          if (e.shiftKey || e.ctrlKey) {
+          if (e.shiftKey || e.metaKey) {
             return selectNoteAction
           }
         }

--- a/app/src/components/PianoRoll/MouseHandler/SelectionMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/SelectionMouseHandler.ts
@@ -22,7 +22,7 @@ export const getSelectionActionForMouseDown =
       return null
     }
 
-    const { selectionBounds } = rootStore.pianoRollStore
+    const { selectionBounds, selectedNoteIds } = rootStore.pianoRollStore
     const local = rootStore.pianoRollStore.getLocal(e)
 
     if (e.button === 0) {
@@ -32,9 +32,9 @@ export const getSelectionActionForMouseDown =
           case "center":
             return moveSelectionAction(selectionBounds)
           case "right":
-            return dragSelectionRightEdgeAction
+            return dragSelectionRightEdgeAction(selectedNoteIds)
           case "left":
-            return dragSelectionLeftEdgeAction
+            return dragSelectionLeftEdgeAction(selectedNoteIds)
           case "outside":
             return createSelectionAction
         }
@@ -152,12 +152,28 @@ const moveSelectionAction =
     })
   }
 
-const dragSelectionLeftEdgeAction = moveDraggableAction({
-  type: "selection",
-  position: "left",
-})
+const dragSelectionLeftEdgeAction = (selectedNoteIds: number[]) =>
+  moveDraggableAction(
+    {
+      type: "selection",
+      position: "left",
+    },
+    selectedNoteIds.map((noteId) => ({
+      type: "note",
+      position: "left",
+      noteId,
+    })),
+  )
 
-const dragSelectionRightEdgeAction = moveDraggableAction({
-  type: "selection",
-  position: "right",
-})
+const dragSelectionRightEdgeAction = (selectedNoteIds: number[]) =>
+  moveDraggableAction(
+    {
+      type: "selection",
+      position: "right",
+    },
+    selectedNoteIds.map((noteId) => ({
+      type: "note",
+      position: "right",
+      noteId,
+    })),
+  )

--- a/app/src/components/PianoRoll/MouseHandler/SelectionMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/SelectionMouseHandler.ts
@@ -116,7 +116,7 @@ const moveSelectionAction =
   (selectedNoteIds: number[]): MouseGesture =>
   (rootStore) =>
   (e) => {
-    const isCopy = e.ctrlKey
+    const isCopy = e.metaKey
 
     if (isCopy) {
       cloneSelection(rootStore)()

--- a/app/src/components/PianoRoll/MouseHandler/SelectionMouseHandler.ts
+++ b/app/src/components/PianoRoll/MouseHandler/SelectionMouseHandler.ts
@@ -189,63 +189,36 @@ const dragSelectionEdgeAction =
         }
 
         const quantize = !e2.shiftKey && isQuantizeEnabled
-        const minLength = quantize ? quantizer.unit : MIN_LENGTH
+        const minLength = quantize ? quantizer.unit * 2 : MIN_LENGTH
         const local = rootStore.pianoRollStore.getLocal(e2)
         const notePoint = NotePoint.add(
           pianoRollStore.transform.getNotePoint(local),
           offset,
         )
 
-        // TODO: pushHistory の処理を追加
-        // TODO: 画面外に出ないようにする処理、選択範囲の最小長を保持する処理を追加
-
-        pianoRollStore.updateDraggable(draggable, () => {
-          if (quantize) {
-            return {
+        const newPosition = quantize
+          ? {
               tick: quantizer.round(notePoint.tick),
               noteNumber: notePoint.noteNumber,
             }
-          }
-          return notePoint
-        })
+          : notePoint
 
-        // const local = pianoRollStore.getLocal(e2)
-        // const tick = pianoRollStore.transform.getTick(local.x)
-        // const fromTick = quantizer.round(tick)
-        // const newSelection = (() => {
-        //   switch (edge) {
-        //     case "left":
-        //       return Selection.resizeLeft(selection, fromTick, minLength)
-        //     case "right":
-        //       return Selection.resizeRight(selection, fromTick, minLength)
-        //   }
-        // })()
+        if (
+          !pianoRollStore.validateDraggablePosition(
+            draggable,
+            newPosition,
+            minLength,
+          )
+        ) {
+          return
+        }
 
-        // if (!Selection.equals(newSelection, selection)) {
-        //   if (!isChanged) {
-        //     isChanged = true
-        //     pushHistory()
-        //   }
-        //   pianoRollStore.selection = newSelection
+        if (!isChanged) {
+          isChanged = true
+          pushHistory()
+        }
 
-        //   switch (edge) {
-        //     case "left": {
-        //       const delta = newSelection.from.tick - selection.from.tick
-        //       updateSelectedNotes(rootStore)((note) => ({
-        //         duration: note.duration - delta,
-        //         tick: note.tick + delta,
-        //       }))
-        //       break
-        //     }
-        //     case "right": {
-        //       const delta = newSelection.to.tick - selection.to.tick
-        //       updateSelectedNotes(rootStore)((note) => ({
-        //         duration: note.duration + delta,
-        //       }))
-        //       break
-        //     }
-        //   }
-        // }
+        pianoRollStore.updateDraggable(draggable, () => newPosition)
       },
     })
   }

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -66,35 +66,48 @@ export const moveDraggableAction =
           return
         }
 
+        const delta = NotePoint.sub(newPosition, draggablePosition)
+
+        const newSubDraggablePositions = subDraggables.map((_, i) => {
+          const subDraggablePosition = subDraggablePositions[i]
+
+          if (subDraggablePosition === null) {
+            return null
+          }
+
+          return NotePoint.add(subDraggablePosition, delta)
+        })
+
+        const someSubDraggablePositionInvalid = newSubDraggablePositions.some(
+          (subDraggablePosition, i) =>
+            subDraggablePosition !== null
+              ? !pianoRollStore.validateDraggablePosition(
+                  subDraggables[i],
+                  subDraggablePosition,
+                  minLength,
+                )
+              : null,
+        )
+
+        if (someSubDraggablePositionInvalid) {
+          return
+        }
+
         if (!isChanged) {
           isChanged = true
           pushHistory()
         }
 
-        pianoRollStore.updateDraggable(draggable, () => newPosition)
-
-        const delta = NotePoint.sub(newPosition, draggablePosition)
+        pianoRollStore.updateDraggable(draggable, newPosition)
 
         subDraggables.forEach((subDraggable, i) => {
-          const subDraggablePosition = subDraggablePositions[i]
+          const subDraggablePosition = newSubDraggablePositions[i]
 
-          if (subDraggablePosition === null) {
+          if (subDraggablePosition === null || subDraggablePosition === null) {
             return
           }
 
-          const newPosition = NotePoint.add(subDraggablePosition, delta)
-
-          if (
-            !pianoRollStore.validateDraggablePosition(
-              subDraggable,
-              newPosition,
-              minLength,
-            )
-          ) {
-            return
-          }
-
-          pianoRollStore.updateDraggable(subDraggable, () => newPosition)
+          pianoRollStore.updateDraggable(subDraggable, subDraggablePosition)
         })
       },
     })

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -1,6 +1,7 @@
+import { Point } from "../../../entities/geometry/Point"
 import { Range } from "../../../entities/geometry/Range"
 import { NotePoint } from "../../../entities/transform/NotePoint"
-import { observeDrag } from "../../../helpers/observeDrag"
+import { observeDrag2 } from "../../../helpers/observeDrag"
 import {
   DraggableArea,
   PianoRollDraggable,
@@ -55,16 +56,16 @@ export const moveDraggableAction =
 
     let isChanged = false
 
-    const local = rootStore.pianoRollStore.getLocal(e)
-    const notePoint = pianoRollStore.transform.getNotePoint(local)
+    const startPos = rootStore.pianoRollStore.getLocal(e)
+    const notePoint = pianoRollStore.transform.getNotePoint(startPos)
     const offset = NotePoint.sub(draggablePosition, notePoint)
 
     const subDraggablePositions = subDraggables.map((subDraggable) =>
       pianoRollStore.getDraggablePosition(subDraggable),
     )
 
-    observeDrag({
-      onMouseMove: (e2) => {
+    observeDrag2(e, {
+      onMouseMove: (e2, d) => {
         const quantize = !e2.shiftKey && isQuantizeEnabled
         const minLength = quantize ? quantizer.unit : MIN_LENGTH
 
@@ -85,7 +86,7 @@ export const moveDraggableAction =
         }
 
         const newPosition = (() => {
-          const local = rootStore.pianoRollStore.getLocal(e2)
+          const local = Point.add(startPos, d)
           const notePoint = NotePoint.add(
             pianoRollStore.transform.getNotePoint(local),
             offset,

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -39,6 +39,9 @@ export const moveDraggableAction =
     draggable: PianoRollDraggable,
     subDraggables: PianoRollDraggable[] = [],
     callback: MoveDraggableCallback = {},
+    behavior:
+      | "moveAlways"
+      | "moveIfSubDraggableMoved" = "moveIfSubDraggableMoved",
   ): MouseGesture =>
   (rootStore) =>
   (e) => {
@@ -132,17 +135,21 @@ export const moveDraggableAction =
           },
         )
 
-        const noSubDraggableMoved = zip(
-          currentSubDraggablePositions,
-          newSubDraggablePositions,
-        ).every(([subDraggablePosition, newSubDraggablePosition]) =>
-          subDraggablePosition && newSubDraggablePosition
-            ? NotePoint.equals(subDraggablePosition, newSubDraggablePosition)
-            : true,
-        )
-
-        if (subDraggablePositions.length > 0 && noSubDraggableMoved) {
-          return
+        if (
+          behavior === "moveIfSubDraggableMoved" &&
+          subDraggablePositions.length > 0
+        ) {
+          const noSubDraggableMoved = zip(
+            currentSubDraggablePositions,
+            newSubDraggablePositions,
+          ).every(([subDraggablePosition, newSubDraggablePosition]) =>
+            subDraggablePosition && newSubDraggablePosition
+              ? NotePoint.equals(subDraggablePosition, newSubDraggablePosition)
+              : true,
+          )
+          if (noSubDraggableMoved) {
+            return
+          }
         }
 
         if (!isChanged) {

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -1,4 +1,3 @@
-import { zip } from "lodash"
 import { Range } from "../../../entities/geometry/Range"
 import { NotePoint } from "../../../entities/transform/NotePoint"
 import { observeDrag } from "../../../helpers/observeDrag"
@@ -39,9 +38,6 @@ export const moveDraggableAction =
     draggable: PianoRollDraggable,
     subDraggables: PianoRollDraggable[] = [],
     callback: MoveDraggableCallback = {},
-    behavior:
-      | "moveAlways"
-      | "moveIfSubDraggableMoved" = "moveIfSubDraggableMoved",
   ): MouseGesture =>
   (rootStore) =>
   (e) => {
@@ -109,10 +105,6 @@ export const moveDraggableAction =
 
         const delta = NotePoint.sub(newPosition, draggablePosition)
 
-        const currentSubDraggablePositions = subDraggables.map((subDraggable) =>
-          pianoRollStore.getDraggablePosition(subDraggable),
-        )
-
         const newSubDraggablePositions = subDraggables.map(
           (subDraggable, i) => {
             const subDraggablePosition = subDraggablePositions[i]
@@ -134,23 +126,6 @@ export const moveDraggableAction =
             return constraintToDraggableArea(position, subDraggableArea)
           },
         )
-
-        if (
-          behavior === "moveIfSubDraggableMoved" &&
-          subDraggablePositions.length > 0
-        ) {
-          const noSubDraggableMoved = zip(
-            currentSubDraggablePositions,
-            newSubDraggablePositions,
-          ).every(([subDraggablePosition, newSubDraggablePosition]) =>
-            subDraggablePosition && newSubDraggablePosition
-              ? NotePoint.equals(subDraggablePosition, newSubDraggablePosition)
-              : true,
-          )
-          if (noSubDraggableMoved) {
-            return
-          }
-        }
 
         if (!isChanged) {
           isChanged = true

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -7,10 +7,17 @@ import { PianoRollDraggable } from "../../../stores/PianoRollStore"
 import { MouseGesture } from "./NoteMouseHandler"
 import { MIN_LENGTH } from "./SelectionMouseHandler"
 
+export interface MoveDraggableCallback {
+  onChange?: (e: MouseEvent, changes: Set<keyof NotePoint>) => void
+  onMouseUp?: (e: MouseEvent) => void
+  onClick?: (e: MouseEvent) => void
+}
+
 export const moveDraggableAction =
   (
     draggable: PianoRollDraggable,
     subDraggables: PianoRollDraggable[] = [],
+    callback: MoveDraggableCallback = {},
   ): MouseGesture =>
   (rootStore) =>
   (e) => {
@@ -38,12 +45,6 @@ export const moveDraggableAction =
 
     observeDrag({
       onMouseMove: (e2) => {
-        const { selection } = pianoRollStore
-
-        if (selection === null) {
-          return
-        }
-
         const quantize = !e2.shiftKey && isQuantizeEnabled
         const minLength = quantize ? quantizer.unit : MIN_LENGTH
         const local = rootStore.pianoRollStore.getLocal(e2)
@@ -120,6 +121,14 @@ export const moveDraggableAction =
             pickValidProps(subDraggablePosition),
           )
         })
+
+        callback?.onChange?.(e2, validProps)
+      },
+      onMouseUp: (e2) => {
+        callback?.onMouseUp?.(e2)
+      },
+      onClick: (e2) => {
+        callback?.onClick?.(e2)
       },
     })
   }

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -60,6 +60,13 @@ export const moveDraggableAction =
             }
           : notePoint
 
+        if (
+          newPosition.tick === draggablePosition.tick &&
+          newPosition.noteNumber === draggablePosition.noteNumber
+        ) {
+          return
+        }
+
         const validProps = pianoRollStore.validateDraggablePosition(
           draggable,
           newPosition,

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -1,0 +1,70 @@
+import { NotePoint } from "../../../entities/transform/NotePoint"
+import { observeDrag } from "../../../helpers/observeDrag"
+import { PianoRollDraggable } from "../../../stores/PianoRollStore"
+import { MouseGesture } from "./NoteMouseHandler"
+import { MIN_LENGTH } from "./SelectionMouseHandler"
+
+export const moveDraggableAction =
+  (draggable: PianoRollDraggable): MouseGesture =>
+  (rootStore) =>
+  (e) => {
+    const {
+      pianoRollStore,
+      pianoRollStore: { isQuantizeEnabled, quantizer },
+      pushHistory,
+    } = rootStore
+
+    const draggablePosition = pianoRollStore.getDraggablePosition(draggable)
+
+    if (draggablePosition === null) {
+      return
+    }
+
+    let isChanged = false
+
+    const local = rootStore.pianoRollStore.getLocal(e)
+    const notePoint = pianoRollStore.transform.getNotePoint(local)
+    const offset = NotePoint.sub(draggablePosition, notePoint)
+
+    observeDrag({
+      onMouseMove: (e2) => {
+        const { selection } = pianoRollStore
+
+        if (selection === null) {
+          return
+        }
+
+        const quantize = !e2.shiftKey && isQuantizeEnabled
+        const minLength = quantize ? quantizer.unit * 2 : MIN_LENGTH
+        const local = rootStore.pianoRollStore.getLocal(e2)
+        const notePoint = NotePoint.add(
+          pianoRollStore.transform.getNotePoint(local),
+          offset,
+        )
+
+        const newPosition = quantize
+          ? {
+              tick: quantizer.round(notePoint.tick),
+              noteNumber: notePoint.noteNumber,
+            }
+          : notePoint
+
+        if (
+          !pianoRollStore.validateDraggablePosition(
+            draggable,
+            newPosition,
+            minLength,
+          )
+        ) {
+          return
+        }
+
+        if (!isChanged) {
+          isChanged = true
+          pushHistory()
+        }
+
+        pianoRollStore.updateDraggable(draggable, () => newPosition)
+      },
+    })
+  }

--- a/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
+++ b/app/src/components/PianoRoll/MouseHandler/moveDraggableAction.ts
@@ -40,14 +40,12 @@ export const moveDraggableAction =
     subDraggables: PianoRollDraggable[] = [],
     callback: MoveDraggableCallback = {},
   ): MouseGesture =>
-  (rootStore) =>
+  ({
+    pianoRollStore,
+    pianoRollStore: { isQuantizeEnabled, transform, quantizer },
+    pushHistory,
+  }) =>
   (e) => {
-    const {
-      pianoRollStore,
-      pianoRollStore: { isQuantizeEnabled, quantizer },
-      pushHistory,
-    } = rootStore
-
     const draggablePosition = pianoRollStore.getDraggablePosition(draggable)
 
     if (draggablePosition === null) {
@@ -56,8 +54,8 @@ export const moveDraggableAction =
 
     let isChanged = false
 
-    const startPos = rootStore.pianoRollStore.getLocal(e)
-    const notePoint = pianoRollStore.transform.getNotePoint(startPos)
+    const startPos = pianoRollStore.getLocal(e)
+    const notePoint = transform.getNotePoint(startPos)
     const offset = NotePoint.sub(draggablePosition, notePoint)
 
     const subDraggablePositions = subDraggables.map((subDraggable) =>
@@ -78,8 +76,7 @@ export const moveDraggableAction =
           return
         }
 
-        const currentPosition =
-          rootStore.pianoRollStore.getDraggablePosition(draggable)
+        const currentPosition = pianoRollStore.getDraggablePosition(draggable)
 
         if (currentPosition === null) {
           return
@@ -87,10 +84,7 @@ export const moveDraggableAction =
 
         const newPosition = (() => {
           const local = Point.add(startPos, d)
-          const notePoint = NotePoint.add(
-            pianoRollStore.transform.getNotePoint(local),
-            offset,
-          )
+          const notePoint = NotePoint.add(transform.getNotePoint(local), offset)
           const position = quantize
             ? {
                 tick: quantizer.round(notePoint.tick),

--- a/app/src/entities/geometry/Range.ts
+++ b/app/src/entities/geometry/Range.ts
@@ -9,6 +9,10 @@ export namespace Range {
     return [start, end]
   }
 
+  export function point(value: number): Range {
+    return [value, value]
+  }
+
   export function contains(range: Range, value: number): boolean {
     const [start, end] = range
     return start <= value && value < end
@@ -18,5 +22,10 @@ export namespace Range {
     const [startA, endA] = a
     const [startB, endB] = b
     return startA < endB && startB < endA
+  }
+
+  export function clamp(range: Range, value: number): number {
+    const [start, end] = range
+    return Math.min(Math.max(start, value), end)
   }
 }

--- a/app/src/entities/geometry/Range.ts
+++ b/app/src/entities/geometry/Range.ts
@@ -1,5 +1,3 @@
-import { Span } from "./Span"
-
 export type Range = [number, number]
 
 export namespace Range {
@@ -20,39 +18,5 @@ export namespace Range {
     const [startA, endA] = a
     const [startB, endB] = b
     return startA < endB && startB < endA
-  }
-
-  // move the start of the range without changing the end
-  export function resizeStart(
-    range: Range,
-    start: number,
-    minLength: number,
-    minStart: number = 0,
-  ): Range {
-    const [, end] = range
-    const newStart = Math.max(minStart, Math.min(start, end - minLength))
-    return [newStart, end]
-  }
-
-  export function resizeEnd(
-    range: Range,
-    end: number,
-    minLength: number,
-    maxEnd: number = Infinity,
-  ): Range {
-    const [start] = range
-    const newEnd = Math.min(maxEnd, Math.max(end, start + minLength))
-    return [start, newEnd]
-  }
-
-  export function toSpan([start, end]: Range): Span {
-    return {
-      start,
-      length: end - start,
-    }
-  }
-
-  export function equals(a: Range, b: Range) {
-    return a[0] === b[0] && a[1] === b[1]
   }
 }

--- a/app/src/entities/geometry/Span.ts
+++ b/app/src/entities/geometry/Span.ts
@@ -1,4 +1,0 @@
-export interface Span {
-  start: number
-  length: number
-}

--- a/app/src/entities/selection/Selection.ts
+++ b/app/src/entities/selection/Selection.ts
@@ -1,5 +1,4 @@
 import { clamp } from "lodash"
-import cloneDeep from "lodash/cloneDeep"
 import { MaxNoteNumber } from "../../Constants"
 import { Rect } from "../geometry/Rect"
 import { NoteCoordTransform } from "../transform/NoteCoordTransform"
@@ -28,8 +27,6 @@ export namespace Selection {
       height: bottom - top,
     }
   }
-
-  export const clone = (selection: Selection): Selection => cloneDeep(selection)
 
   export const moved = (
     selection: Selection,

--- a/app/src/entities/selection/Selection.ts
+++ b/app/src/entities/selection/Selection.ts
@@ -1,6 +1,5 @@
 import cloneDeep from "lodash/cloneDeep"
 import { MaxNoteNumber } from "../../Constants"
-import { Range } from "../geometry/Range"
 import { Rect } from "../geometry/Rect"
 import { NoteCoordTransform } from "../transform/NoteCoordTransform"
 import { NotePoint } from "../transform/NotePoint"
@@ -91,40 +90,5 @@ export namespace Selection {
     selection.to.noteNumber = Math.floor(selection.to.noteNumber)
 
     return Selection.clamp(selection)
-  }
-
-  // Fix the right end and change the length
-  export function resizeLeft(
-    selection: Selection,
-    tick: number,
-    minLength: number,
-  ) {
-    const range = Range.create(selection.from.tick, selection.to.tick)
-    const [newFromTick, newToTick] = Range.resizeStart(range, tick, minLength)
-    return Selection.regularized(
-      newFromTick,
-      selection.from.noteNumber,
-      newToTick,
-      selection.to.noteNumber,
-    )
-  }
-
-  export function resizeRight(
-    selection: Selection,
-    tick: number,
-    minLength: number,
-  ) {
-    const range = Range.create(selection.from.tick, selection.to.tick)
-    const [newFromTick, newToTick] = Range.resizeEnd(range, tick, minLength)
-    return Selection.regularized(
-      newFromTick,
-      selection.from.noteNumber,
-      newToTick,
-      selection.to.noteNumber,
-    )
-  }
-
-  export function equals(a: Selection, b: Selection) {
-    return NotePoint.equals(a.from, b.from) && NotePoint.equals(a.to, b.to)
   }
 }

--- a/app/src/entities/selection/Selection.ts
+++ b/app/src/entities/selection/Selection.ts
@@ -1,3 +1,4 @@
+import { clamp } from "lodash"
 import cloneDeep from "lodash/cloneDeep"
 import { MaxNoteNumber } from "../../Constants"
 import { Rect } from "../geometry/Rect"
@@ -5,8 +6,10 @@ import { NoteCoordTransform } from "../transform/NoteCoordTransform"
 import { NotePoint } from "../transform/NotePoint"
 
 export interface Selection {
-  from: NotePoint
-  to: NotePoint
+  fromTick: number
+  fromNoteNumber: number
+  toTick: number
+  toNoteNumber: number
 }
 
 export namespace Selection {
@@ -14,10 +17,10 @@ export namespace Selection {
     selection: Selection,
     transform: NoteCoordTransform,
   ): Rect => {
-    const left = transform.getX(selection.from.tick)
-    const right = transform.getX(selection.to.tick)
-    const top = transform.getY(selection.from.noteNumber)
-    const bottom = transform.getY(selection.to.noteNumber)
+    const left = transform.getX(selection.fromTick)
+    const right = transform.getX(selection.toTick)
+    const top = transform.getY(selection.fromNoteNumber)
+    const bottom = transform.getY(selection.toNoteNumber)
     return {
       x: left,
       y: top,
@@ -33,62 +36,37 @@ export namespace Selection {
     dt: number,
     dn: number,
   ): Selection => {
-    const s = clone(selection)
-
-    s.from.tick += dt
-    s.to.tick += dt
-    s.from.noteNumber += dn
-    s.to.noteNumber += dn
-
-    return s
+    return {
+      fromTick: selection.fromTick + dt,
+      fromNoteNumber: selection.fromNoteNumber + dn,
+      toTick: selection.toTick + dt,
+      toNoteNumber: selection.toNoteNumber + dn,
+    }
   }
 
-  // to Make the lower right
-  export const regularized = (
-    fromTick: number,
-    fromNoteNumber: number,
-    toTick: number,
-    toNoteNumber: number,
-  ): Selection => ({
-    from: {
-      tick: Math.max(0, Math.min(fromTick, toTick)),
-      noteNumber: Math.min(
-        MaxNoteNumber,
-        Math.max(fromNoteNumber, toNoteNumber),
-      ),
-    },
-    to: {
-      tick: Math.max(fromTick, toTick),
-      noteNumber: Math.min(
-        MaxNoteNumber,
-        Math.min(fromNoteNumber, toNoteNumber),
-      ),
-    },
-  })
-
-  export const clamp = (selection: Selection): Selection => ({
-    from: clampNotePoint(selection.from),
-    to: clampNotePoint(selection.to),
-  })
-
-  // Unlike NotePoint.clamp, noteNumber may be -1
-  const clampNotePoint = (point: NotePoint): NotePoint => ({
-    tick: Math.max(0, point.tick),
-    noteNumber: Math.min(MaxNoteNumber, Math.max(-1, point.noteNumber)),
-  })
-
   export function fromPoints(start: NotePoint, end: NotePoint) {
-    let selection = Selection.regularized(
-      start.tick,
-      start.noteNumber,
-      end.tick,
-      end.noteNumber,
-    )
+    const leftTick = Math.min(start.tick, end.tick)
+    const rightTick = Math.max(start.tick, end.tick)
 
     // integer containing the original coordinates.
-    selection.from.noteNumber = Math.ceil(selection.from.noteNumber)
-    selection.to.noteNumber = Math.floor(selection.to.noteNumber)
+    const topNoteNumber = Math.ceil(Math.max(start.noteNumber, end.noteNumber))
+    const bottomNoteNumber = Math.floor(
+      Math.min(start.noteNumber, end.noteNumber),
+    )
 
-    return Selection.clamp(selection)
+    return {
+      fromTick: Math.max(0, leftTick),
+      fromNoteNumber: clamp(topNoteNumber, -1, MaxNoteNumber),
+      toTick: Math.max(0, rightTick),
+      toNoteNumber: clamp(bottomNoteNumber, -1, MaxNoteNumber),
+    }
+  }
+
+  export function getFrom(selection: Selection): NotePoint {
+    return { tick: selection.fromTick, noteNumber: selection.fromNoteNumber }
+  }
+
+  export function getTo(selection: Selection): NotePoint {
+    return { tick: selection.toTick, noteNumber: selection.toNoteNumber }
   }
 }

--- a/app/src/entities/transform/NotePoint.ts
+++ b/app/src/entities/transform/NotePoint.ts
@@ -17,4 +17,18 @@ export namespace NotePoint {
   export function equals(a: NotePoint, b: NotePoint): boolean {
     return a.tick === b.tick && a.noteNumber === b.noteNumber
   }
+
+  export function sub(a: NotePoint, b: NotePoint): NotePoint {
+    return {
+      tick: a.tick - b.tick,
+      noteNumber: a.noteNumber - b.noteNumber,
+    }
+  }
+
+  export function add(a: NotePoint, b: NotePoint): NotePoint {
+    return {
+      tick: a.tick + b.tick,
+      noteNumber: a.noteNumber + b.noteNumber,
+    }
+  }
 }

--- a/app/src/helpers/set.ts
+++ b/app/src/helpers/set.ts
@@ -1,0 +1,9 @@
+export function intersection<T>(a: Set<T>, b: Set<T>): Set<T> {
+  const result = new Set<T>()
+  for (const item of a) {
+    if (b.has(item)) {
+      result.add(item)
+    }
+  }
+  return result
+}

--- a/app/src/stores/PianoRollStore.ts
+++ b/app/src/stores/PianoRollStore.ts
@@ -529,20 +529,38 @@ export default class PianoRollStore {
       return null
     }
     switch (draggable.type) {
-      case "note":
+      case "note": {
         const note = selectedTrack.getEventById(draggable.noteId)
         if (note === undefined || !isNoteEvent(note)) {
           return null
         }
+        const notes = this.selectedNoteIds
+          .map((id) => selectedTrack.getEventById(id))
+          .filter(isNotUndefined)
+          .filter(isNoteEvent)
+        const minTick = min(notes.map((n) => n.tick)) ?? 0
+        const tickLowerBound = note.tick - minTick
         switch (draggable.position) {
-          case "center":
+          case "center": {
+            const maxNoteNumber = max(notes.map((n) => n.noteNumber)) ?? 0
+            const minNoteNumber = min(notes.map((n) => n.noteNumber)) ?? 0
+            const noteNumberLowerBound = note.noteNumber - minNoteNumber
+            const noteNumberUpperBound =
+              MaxNoteNumber - (maxNoteNumber - note.noteNumber)
             return {
-              tickRange: Range.create(0, Infinity),
-              noteNumberRange: Range.create(0, MaxNoteNumber + 1),
+              tickRange: Range.create(tickLowerBound, Infinity),
+              noteNumberRange: Range.create(
+                noteNumberLowerBound,
+                noteNumberUpperBound,
+              ),
             }
+          }
           case "left":
             return {
-              tickRange: Range.create(0, note.tick + note.duration - minLength),
+              tickRange: Range.create(
+                tickLowerBound,
+                note.tick + note.duration - minLength,
+              ),
               noteNumberRange: Range.point(note.noteNumber), // allow to move only vertically
             }
           case "right":
@@ -551,7 +569,8 @@ export default class PianoRollStore {
               noteNumberRange: Range.point(note.noteNumber), // allow to move only vertically
             }
         }
-      case "selection":
+      }
+      case "selection": {
         const { selection } = this
         if (selection === null) {
           return null
@@ -609,6 +628,7 @@ export default class PianoRollStore {
             }
           }
         }
+      }
     }
   }
 }

--- a/app/src/stores/PianoRollStore.ts
+++ b/app/src/stores/PianoRollStore.ts
@@ -436,10 +436,7 @@ export default class PianoRollStore {
     }
   }
 
-  updateDraggable(
-    draggable: PianoRollDraggable,
-    update: (position: NotePoint) => NotePoint,
-  ) {
+  updateDraggable(draggable: PianoRollDraggable, position: NotePoint) {
     switch (draggable.type) {
       case "note":
         const { selectedTrack } = this
@@ -452,12 +449,10 @@ export default class PianoRollStore {
         }
         switch (draggable.position) {
           case "center": {
-            const position = update(note)
             selectedTrack.updateEvent(note.id, position)
             break
           }
           case "left": {
-            const position = update(note)
             selectedTrack.updateEvent(note.id, {
               tick: position.tick,
               duration: note.duration + note.tick - position.tick,
@@ -465,10 +460,6 @@ export default class PianoRollStore {
             break
           }
           case "right": {
-            const position = update({
-              tick: note.tick + note.duration,
-              noteNumber: note.noteNumber,
-            })
             selectedTrack.updateEvent(note.id, {
               duration: position.tick - note.tick,
             })
@@ -483,7 +474,6 @@ export default class PianoRollStore {
         }
         switch (draggable.position) {
           case "center": {
-            const position = update(selection.from)
             this.selection = Selection.moved(
               selection,
               position.tick,
@@ -493,13 +483,13 @@ export default class PianoRollStore {
           }
           case "left": {
             const newSelection = Selection.clone(selection)
-            newSelection.from.tick = update(selection.from).tick
+            newSelection.from.tick = position.tick
             this.selection = newSelection
             break
           }
           case "right": {
             const newSelection = Selection.clone(selection)
-            newSelection.to.tick = update(selection.to).tick
+            newSelection.to.tick = position.tick
             this.selection = newSelection
             break
           }

--- a/app/src/stores/PianoRollStore.ts
+++ b/app/src/stores/PianoRollStore.ts
@@ -427,11 +427,11 @@ export default class PianoRollStore {
         }
         switch (draggable.position) {
           case "center":
-            return selection.from
+            return Selection.getFrom(selection)
           case "left":
-            return selection.from
+            return Selection.getFrom(selection)
           case "right":
-            return selection.to
+            return Selection.getTo(selection)
         }
     }
   }
@@ -480,12 +480,14 @@ export default class PianoRollStore {
         }
         switch (draggable.position) {
           case "center": {
-            const defaultedPosition = { ...selection.from, ...position }
-            const delta = NotePoint.sub(defaultedPosition, selection.from)
-            this.selection = {
-              from: defaultedPosition,
-              to: NotePoint.add(selection.to, delta),
-            }
+            const from = Selection.getFrom(selection)
+            const defaultedPosition = { ...from, ...position }
+            const delta = NotePoint.sub(defaultedPosition, from)
+            this.selection = Selection.moved(
+              selection,
+              delta.tick,
+              delta.noteNumber,
+            )
             break
           }
           case "left": {
@@ -493,7 +495,7 @@ export default class PianoRollStore {
               return
             }
             const newSelection = Selection.clone(selection)
-            newSelection.from.tick = position.tick
+            newSelection.fromTick = position.tick
             this.selection = newSelection
             break
           }
@@ -502,7 +504,7 @@ export default class PianoRollStore {
               return
             }
             const newSelection = Selection.clone(selection)
-            newSelection.to.tick = position.tick
+            newSelection.toTick = position.tick
             this.selection = newSelection
             break
           }
@@ -554,7 +556,7 @@ export default class PianoRollStore {
         }
         switch (draggable.position) {
           case "center":
-            const height = selection.from.noteNumber - selection.to.noteNumber
+            const height = selection.fromNoteNumber - selection.toNoteNumber
             return validNotePointSet({
               tick: position.tick >= 0,
               noteNumber:
@@ -567,13 +569,13 @@ export default class PianoRollStore {
             return validNotePointSet({
               tick:
                 position.tick >= 0 &&
-                position.tick <= selection.to.tick - minLength,
+                position.tick <= selection.toTick - minLength,
             })
           case "right":
             return validNotePointSet({
               tick:
                 position.tick >= 0 &&
-                position.tick >= selection.from.tick + minLength,
+                position.tick >= selection.fromTick + minLength,
             })
         }
     }

--- a/app/src/stores/PianoRollStore.ts
+++ b/app/src/stores/PianoRollStore.ts
@@ -149,7 +149,7 @@ export default class PianoRollStore {
 
   serialize(): SerializedPianoRollStore {
     return {
-      selection: this.selection ? Selection.clone(this.selection) : null,
+      selection: this.selection ? { ...this.selection } : null,
       selectedNoteIds: cloneDeep(this.selectedNoteIds),
       selectedTrackId: this.selectedTrackId,
     }
@@ -494,18 +494,20 @@ export default class PianoRollStore {
             if (position.tick === undefined) {
               return
             }
-            const newSelection = Selection.clone(selection)
-            newSelection.fromTick = position.tick
-            this.selection = newSelection
+            this.selection = {
+              ...selection,
+              fromTick: position.tick,
+            }
             break
           }
           case "right": {
             if (position.tick === undefined) {
               return
             }
-            const newSelection = Selection.clone(selection)
-            newSelection.toTick = position.tick
-            this.selection = newSelection
+            this.selection = {
+              ...selection,
+              toTick: position.tick,
+            }
             break
           }
         }


### PR DESCRIPTION
A regression was occurring in the ability to resize multiple notes at the same time when in pencil mode. While fixing this, the handling of moving and resizing notes and selections has been overhauled.

## `PianoRollDraggable`

The left, center, and right ends of notes and the left, center, and right ends of selections are represented by the concept `PianoRollDraggable`, respectively. The `PianoRollDraggable` can be retrieved and updated from the PianoRollStore.

For example, an operation that changes the length of a note by dragging its right edge corresponds to moving the PianoRollDraggable on the right edge of the note.

## `moveDraggableAction`

Move operations are unified into `moveDraggableAction`. The `moveDraggableAction` allows you to move the `PianoRollDraggable` you want to move, and multiple `PianoRollDraggables` associated with it, simultaneously by dragging. Each `PianoRollDraggable` has its own movement limit, and the range of movement is adjusted according to the position of the selected notes, etc. to prevent inappropriate movement.

## Temporary quantization disablement 

Also, while it has been possible to temporarily disable quantize by pressing the Shift key when adjusting note size, I have added this functionality to `moveDraggableAction` so that quantize can be disabled by pressing the Shift key during any move or resize.