### PR TITLE
route MIDI device channels

### DIFF
--- a/app/src/actions/song.ts
+++ b/app/src/actions/song.ts
@@ -94,6 +94,7 @@ export const selectTrack =
   ({ pianoRollStore }: RootStore) =>
   (trackId: TrackId) => {
     pianoRollStore.selectedTrackId = trackId
+    pianoRollStore.previewingNoteNumbers.clear()
   }
 
 export const insertTrack =

--- a/app/src/services/MIDIInput.ts
+++ b/app/src/services/MIDIInput.ts
@@ -22,7 +22,7 @@ export class MIDIInput {
     this.devices.push(device)
   }
 
-  onMidiMessage = (e: WebMidi.MIDIMessageEvent) => {
+  private onMidiMessage = (e: WebMidi.MIDIMessageEvent) => {
     this.onMessage?.(e)
   }
 }
@@ -42,7 +42,7 @@ export const previewMidiInput =
       return
     }
 
-    // TODO: seems like if sending to a channel which is not mapped to a Track, it defaults to playing the default piano. This should not happen.
+    // TODO: seems like if sending to a channel which is not mapped to a Track, it defaults to playing the default piano (or Drums on CH 10). This should not happen.
     player.sendEvent(event)
 
     // optional, only showing notes in piano roll if its the same channel as selected track

--- a/app/src/services/MIDIInput.ts
+++ b/app/src/services/MIDIInput.ts
@@ -3,7 +3,7 @@ import RootStore from "../stores/RootStore"
 
 export class MIDIInput {
   private devices: WebMidi.MIDIInput[] = []
-  onMessage: ((e: WebMidi.MIDIMessageEvent) => void) | undefined
+  onMessage: ((data: Uint8Array) => void) | undefined
 
   removeAllDevices = () => {
     this.devices.forEach(this.removeDevice)
@@ -23,19 +23,19 @@ export class MIDIInput {
   }
 
   private onMidiMessage = (e: WebMidi.MIDIMessageEvent) => {
-    this.onMessage?.(e)
+    this.onMessage?.(e.data)
   }
 }
 
 export const previewMidiInput =
-  (rootStore: RootStore) => (e: WebMidi.MIDIMessageEvent) => {
+  (rootStore: RootStore) => (dataRaw: Uint8Array) => {
     const {
       pianoRollStore,
       pianoRollStore: { selectedTrack },
       player,
     } = rootStore
 
-    const stream = new Stream(e.data)
+    const stream = new Stream(dataRaw)
     const event = deserializeSingleEvent(stream)
 
     if (event.type !== "channel") {

--- a/app/src/services/MIDIInput.ts
+++ b/app/src/services/MIDIInput.ts
@@ -42,6 +42,7 @@ export const previewMidiInput =
       return
     }
 
+    // TODO: seems like if sending to a channel which is not mapped to a Track, it defaults to playing the default piano. This should not happen.
     player.sendEvent(event)
 
     // optional, only showing notes in piano roll if its the same channel as selected track

--- a/app/src/services/MIDIInput.ts
+++ b/app/src/services/MIDIInput.ts
@@ -34,13 +34,6 @@ export const previewMidiInput =
       pianoRollStore: { selectedTrack },
       player,
     } = rootStore
-    if (selectedTrack === undefined) {
-      return
-    }
-    const { channel } = selectedTrack
-    if (channel === undefined) {
-      return
-    }
 
     const stream = new Stream(e.data)
     const event = deserializeSingleEvent(stream)
@@ -49,10 +42,10 @@ export const previewMidiInput =
       return
     }
 
-    // modify channel to the selected track channel
-    event.channel = channel
-
     player.sendEvent(event)
+
+    // optional, only showing notes in piano roll if its the same channel as selected track
+    if (event.channel !== selectedTrack?.channel) return;
 
     if (event.subtype === "noteOn") {
       pianoRollStore.previewingNoteNumbers.add(event.noteNumber)

--- a/app/src/services/MIDIRecorder.ts
+++ b/app/src/services/MIDIRecorder.ts
@@ -53,12 +53,12 @@ export class MIDIRecorder {
     })
   }
 
-  onMessage(e: WebMidi.MIDIMessageEvent) {
+  onMessage(dataRaw: Uint8Array) {
     if (!this.isRecording) {
       return
     }
 
-    const stream = new Stream(e.data)
+    const stream = new Stream(dataRaw)
     const message = deserializeSingleEvent(stream)
     if (message.type !== "channel") {
       return

--- a/app/src/stores/RootStore.ts
+++ b/app/src/stores/RootStore.ts
@@ -103,7 +103,7 @@ export default class RootStore {
 
     const preview = previewMidiInput(this)
 
-    this.midiInput.onMidiMessage = (e) => {
+    this.midiInput.onMessage = (e) => {
       preview(e)
       this.midiRecorder.onMessage(e)
     }

--- a/app/src/stores/RootStore.ts
+++ b/app/src/stores/RootStore.ts
@@ -103,9 +103,9 @@ export default class RootStore {
 
     const preview = previewMidiInput(this)
 
-    this.midiInput.onMessage = (e) => {
-      preview(e)
-      this.midiRecorder.onMessage(e)
+    this.midiInput.onMessage = (dataRaw) => {
+      preview(dataRaw)
+      this.midiRecorder.onMessage(dataRaw)
     }
 
     this.pianoRollStore.setUpAutorun()


### PR DESCRIPTION
I am the creator of this physical MIDI device: https://wavyindustries.com/monkey
It heavily relies on MIDI channels, and routing them to their own Track/Instrument.

- Updated the code to make it such that the MIDI coming from external MIDI device is routed to the Track or Tracks corresponding to this MIDI channel

Possible improvements:
- If no instrument is routed to the MIDI channel of the selected device, there is no feedback in the GUI.
=> Add some sort of visual feedback of incoming (and perhaps outgoing) MIDI events
- Only the messages which are sent to the selected MIDI track is visualised in the Piano Roll. Add some effect to the track to indicate it is receiving MIDI events, such that it's possible to visualise which of the tracks are receiving the events

- [ ] notes in piano roll are not released when switching over to a new Track, which makes them hanging in GUI

Demo, everything is recorded on device, only using Signal to "transform MIDI to sound"
https://github.com/user-attachments/assets/ec2ee251-c1fd-4e19-9dbc-e49328d367df

