### PR TITLE
Allow 'select all' to work even when no notes are selected

### DIFF
--- a/app/src/components/KeyboardShortcut/PianoRollKeyboardShortcut.tsx
+++ b/app/src/components/KeyboardShortcut/PianoRollKeyboardShortcut.tsx
@@ -48,9 +48,7 @@ export const PianoRollKeyboardShortcut: FC = observer(() => {
   return (
     <KeyboardShortcut
       actions={[
-        ...(pianoRollStore.selectedNoteIds.length > 0
-          ? pianoNotesKeyboardShortcutActions()
-          : []),
+        ...pianoNotesKeyboardShortcutActions(),
         ...(controlStore.selectedEventIds.length > 0
           ? controlPaneKeyboardShortcutActions()
           : []),


### PR DESCRIPTION
I was trying to merge two tracks, and I noticed it was much more difficult than it needed to be, because the "select all" shortcut wasn't working unless at least one note was already selected.

This PR lets "select all" always work, and seems to have no adverse effects. (I haven't tested every possible shortcut in `usePianoNotesKeyboardShortcutActions` though.  Will one of them throw an error if no notes are selected?)