### PR TITLE
Revert "Allow 'select all' to work even when no notes are selected"

### DIFF
--- a/app/src/components/KeyboardShortcut/PianoRollKeyboardShortcut.tsx
+++ b/app/src/components/KeyboardShortcut/PianoRollKeyboardShortcut.tsx
@@ -48,7 +48,9 @@ export const PianoRollKeyboardShortcut: FC = observer(() => {
   return (
     <KeyboardShortcut
       actions={[
-        ...pianoNotesKeyboardShortcutActions(),
+        ...(pianoRollStore.selectedNoteIds.length > 0
+          ? pianoNotesKeyboardShortcutActions()
+          : []),
         ...(controlStore.selectedEventIds.length > 0
           ? controlPaneKeyboardShortcutActions()
           : []),


### PR DESCRIPTION
Reverts ryohey/signal#439

#445
