### PR TITLE
Fix compile errors

### DIFF
--- a/app/src/components/ControlPane/LineGraph/LineGraph.tsx
+++ b/app/src/components/ControlPane/LineGraph/LineGraph.tsx
@@ -110,7 +110,6 @@ const LineGraph = observer(
             hitEventId,
             local,
             controlTransform,
-            eventType,
           )
         } else {
           createSelectionGesture.onMouseDown(

--- a/app/src/components/InstrumentBrowser/SelectBox.tsx
+++ b/app/src/components/InstrumentBrowser/SelectBox.tsx
@@ -47,7 +47,7 @@ const Option: FC<
   )
 }
 
-export const SelectBox = <T extends object>({
+export const SelectBox = <T,>({
   items,
   selectedValue,
   onChange,


### PR DESCRIPTION
I did a fresh checkout of Signal just now. To my surprise, `npm run build` followed by `npm start` ended up showing two compile errors. When I opened it in Webstorm the IDE confirmed there were problems.

# Problem 1
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/561b4154-c0a3-4aa3-97f5-12e4f178d527" />

```tsx
            <SelectBox
              items={categoryOptions}
              selectedValue={selectedCategoryId} // Error TS2322: Type 'number' is not assignable to type 'object'.
              onChange={(i) =>
                onChange({
                  programNumber: i * 8, // Choose the first instrument of the category
                  isRhythmTrack,
                })
              }
            />
```

Since `selectedCategoryId` is a number, then `SelectBox<T>` becomes `SelectBox<number>`. However, `SelectBox` currently requires `SelectBox<T extends object>`, causing an error because `number` doesn't extend `object`.

## Solution 1
Removed `extends object`

# Problem 2
<img width="643" alt="image" src="https://github.com/user-attachments/assets/928d0bd9-e835-44fb-8216-703fcf6539dc" />

```tsx
          dragSelectionGesture.onMouseDown(
            ev.nativeEvent,
            hitEventId,
            local,
            controlTransform,
            eventType, // Error TS2554: Expected 4 arguments, but got 5.
          )
```
The above `onMouseDown` method only takes 4 arguments:

```tsx
    onMouseDown<T extends ControllerEvent | PitchBendEvent>(
      e: MouseEvent,
      hitEventId: number,
      startPoint: Point,
      transform: ControlCoordTransform,
    ) {
```

## Solution 2
Removed `eventType,` from the list of args passed to `onMouseDown`

---

Looking at the git blame, those lines of code haven't changed in a very long time (since 2022), so I wonder why the compiler is suddenly detecting these errors. Were there recent changes to tsconfig? Or could it be because you made `eslint` changes? Either way, it's nice that these were caught. (Maybe they were warnings before?)