### PR TITLE
Improve perfomance

### DIFF
--- a/app/src/actions/export.ts
+++ b/app/src/actions/export.ts
@@ -17,6 +17,8 @@ export const useExportSong = () => {
   const dialog = useDialog()
 
   return async (format: "WAV" | "MP3") => {
+    song.updateEndOfSong()
+
     if (!canExport(song)) {
       await dialog.show({
         title: localized["export"],

--- a/app/src/actions/selection.ts
+++ b/app/src/actions/selection.ts
@@ -16,7 +16,10 @@ import clipboard from "../services/Clipboard"
 import { NoteEvent, TrackEvent, isNoteEvent } from "../track"
 import { useStartNote, useStopNote } from "./player"
 
-export function eventsInSelection(events: TrackEvent[], selection: Selection) {
+export function eventsInSelection(
+  events: readonly TrackEvent[],
+  selection: Selection,
+) {
   const selectionRect = {
     x: selection.fromTick,
     width: selection.toTick - selection.fromTick,

--- a/app/src/clipboard/clipboardTypes.ts
+++ b/app/src/clipboard/clipboardTypes.ts
@@ -23,7 +23,7 @@ export const isArrangeNotesClipboardData = (
 
 export interface ControlEventsClipboardData {
   type: "control_events"
-  events: TrackEvent[]
+  events: readonly TrackEvent[]
 }
 
 export const isControlEventsClipboardData = (

--- a/app/src/components/PianoRoll/PianoControlEvents.tsx
+++ b/app/src/components/PianoRoll/PianoControlEvents.tsx
@@ -54,7 +54,7 @@ function isDisplayControlEvent(e: TrackEvent): e is DisplayEvent {
 
 export interface PianoControlEventsProps {
   width: number
-  events: TrackEvent[]
+  events: readonly TrackEvent[]
   scrollLeft: number
   transform: TickTransform
   onDoubleClickMark: (group: DisplayEvent[]) => void

--- a/app/src/components/TempoGraph/transformEvents.ts
+++ b/app/src/components/TempoGraph/transformEvents.ts
@@ -3,7 +3,7 @@ import { isSetTempoEvent, TrackEvent } from "../../track"
 import { TempoGraphItem } from "./TempoGraphItem"
 
 export const transformEvents = (
-  events: TrackEvent[],
+  events: readonly TrackEvent[],
   transform: TempoCoordTransform,
   maxX: number,
 ): TempoGraphItem[] => {

--- a/app/src/helpers/OrderedArray.test.ts
+++ b/app/src/helpers/OrderedArray.test.ts
@@ -1,0 +1,175 @@
+import { OrderedArray } from "./OrderedArray"
+
+describe("OrderedArray", () => {
+  interface TestItem {
+    id: number
+    rowIndex: number
+    name: string
+  }
+
+  let items: TestItem[]
+  let orderedArray: OrderedArray<TestItem>
+
+  beforeEach(() => {
+    // Reset items before each test
+    items = [
+      { id: 3, rowIndex: 30, name: "Charlie" },
+      { id: 1, rowIndex: 10, name: "Alice" },
+      { id: 2, rowIndex: 20, name: "Bob" }
+    ]
+    orderedArray = new OrderedArray(items, (item) => item.rowIndex)
+  })
+
+  test("should sort the array on initialization", () => {
+    const sorted = orderedArray.getArray()
+    expect(sorted[0].rowIndex).toBe(10)
+    expect(sorted[1].rowIndex).toBe(20)
+    expect(sorted[2].rowIndex).toBe(30)
+  })
+
+  test("should sort in descending order when specified", () => {
+    const descendingArray = new OrderedArray(
+      [...items],
+      (item) => item.rowIndex,
+      true
+    )
+    const sorted = descendingArray.getArray()
+    expect(sorted[0].rowIndex).toBe(30)
+    expect(sorted[1].rowIndex).toBe(20)
+    expect(sorted[2].rowIndex).toBe(10)
+  })
+
+  test("should add an element in the correct position", () => {
+    orderedArray.add({ id: 4, rowIndex: 15, name: "Dave" })
+    const array = orderedArray.getArray()
+    
+    expect(array.length).toBe(4)
+    expect(array[0].rowIndex).toBe(10)
+    expect(array[1].rowIndex).toBe(15)
+    expect(array[2].rowIndex).toBe(20)
+    expect(array[3].rowIndex).toBe(30)
+  })
+
+  test("should add an element in the correct position in descending order", () => {
+    const descendingArray = new OrderedArray(
+      [...items],
+      (item) => item.rowIndex,
+      true
+    )
+    
+    descendingArray.add({ id: 4, rowIndex: 15, name: "Dave" })
+    const array = descendingArray.getArray()
+    
+    expect(array.length).toBe(4)
+    expect(array[0].rowIndex).toBe(30)
+    expect(array[1].rowIndex).toBe(20)
+    expect(array[2].rowIndex).toBe(15)
+    expect(array[3].rowIndex).toBe(10)
+  })
+
+  test("should remove an element by id", () => {
+    orderedArray.remove(2) // remove Bob
+    const array = orderedArray.getArray()
+    
+    expect(array.length).toBe(2)
+    expect(array[0].name).toBe("Alice")
+    expect(array[1].name).toBe("Charlie")
+  })
+
+  test("should update an element and maintain correct order", () => {
+    // Update Bob's rowIndex to 5
+    orderedArray.update(2, { rowIndex: 5 })
+    const array = orderedArray.getArray()
+    
+    expect(array.length).toBe(3)
+    expect(array[0].name).toBe("Bob") // Bob should now be first
+    expect(array[1].name).toBe("Alice")
+    expect(array[2].name).toBe("Charlie")
+  })
+
+  test("should update an element and maintain correct descending order", () => {
+    const descendingArray = new OrderedArray(
+      [...items],
+      (item) => item.rowIndex,
+      true
+    )
+    
+    // Update Bob's rowIndex to 5
+    descendingArray.update(2, { rowIndex: 5 })
+    const array = descendingArray.getArray()
+    
+    expect(array.length).toBe(3)
+    expect(array[0].name).toBe("Charlie")
+    expect(array[1].name).toBe("Alice")
+    expect(array[2].name).toBe("Bob") // Bob should now be last
+  })
+
+  test("should handle elements with same key by using id for stable ordering", () => {
+    // Add element with same rowIndex but different id
+    orderedArray.add({ id: 4, rowIndex: 20, name: "David" })
+    const array = orderedArray.getArray()
+    
+    // Check that elements with same rowIndex are ordered by id
+    const indexOfBob = array.findIndex(item => item.name === "Bob")
+    const indexOfDavid = array.findIndex(item => item.name === "David")
+    
+    expect(array.length).toBe(4)
+    // Bob (id: 2) should come before David (id: 4) since both have rowIndex 20
+    expect(indexOfBob).toBeLessThan(indexOfDavid)
+  })
+
+  test("should handle empty array", () => {
+    const emptyArray = new OrderedArray<TestItem>([], (item) => item.rowIndex)
+    expect(emptyArray.getArray().length).toBe(0)
+    
+    // Add an element to empty array
+    emptyArray.add({ id: 1, rowIndex: 10, name: "Alice" })
+    expect(emptyArray.getArray().length).toBe(1)
+    expect(emptyArray.getArray()[0].name).toBe("Alice")
+  })
+
+  test("should handle edge cases: add at beginning, middle, and end", () => {
+    // Add at beginning
+    orderedArray.add({ id: 4, rowIndex: 5, name: "First" })
+    // Add at end
+    orderedArray.add({ id: 5, rowIndex: 40, name: "Last" })
+    // Add in middle
+    orderedArray.add({ id: 6, rowIndex: 25, name: "Middle" })
+    
+    const array = orderedArray.getArray()
+    
+    expect(array.length).toBe(6)
+    expect(array[0].name).toBe("First")
+    expect(array[1].name).toBe("Alice")
+    expect(array[2].name).toBe("Bob")
+    expect(array[3].name).toBe("Middle")
+    expect(array[4].name).toBe("Charlie")
+    expect(array[5].name).toBe("Last")
+  })
+
+  test("should retrieve elements by id in O(1) time", () => {
+    const alice = orderedArray.get(1)
+    const bob = orderedArray.get(2)
+    const charlie = orderedArray.get(3)
+    const nonExistent = orderedArray.get(999)
+    
+    expect(alice).toBeDefined()
+    expect(alice?.name).toBe("Alice")
+    expect(bob?.name).toBe("Bob")
+    expect(charlie?.name).toBe("Charlie")
+    expect(nonExistent).toBeUndefined()
+    
+    // Test that the map is updated after add/remove/update operations
+    orderedArray.add({ id: 4, rowIndex: 15, name: "Dave" })
+    const dave = orderedArray.get(4)
+    expect(dave?.name).toBe("Dave")
+    
+    orderedArray.update(2, { name: "Bobby" })
+    const bobby = orderedArray.get(2)
+    expect(bobby?.name).toBe("Bobby")
+    
+    orderedArray.remove(1) // Remove Alice
+    const aliceAfterRemove = orderedArray.get(1)
+    expect(aliceAfterRemove).toBeUndefined()
+  })
+})

--- a/app/src/helpers/OrderedArray.test.ts
+++ b/app/src/helpers/OrderedArray.test.ts
@@ -15,7 +15,7 @@ describe("OrderedArray", () => {
     items = [
       { id: 3, rowIndex: 30, name: "Charlie" },
       { id: 1, rowIndex: 10, name: "Alice" },
-      { id: 2, rowIndex: 20, name: "Bob" }
+      { id: 2, rowIndex: 20, name: "Bob" },
     ]
     orderedArray = new OrderedArray(items, (item) => item.rowIndex)
   })
@@ -31,7 +31,7 @@ describe("OrderedArray", () => {
     const descendingArray = new OrderedArray(
       [...items],
       (item) => item.rowIndex,
-      true
+      true,
     )
     const sorted = descendingArray.getArray()
     expect(sorted[0].rowIndex).toBe(30)
@@ -42,7 +42,7 @@ describe("OrderedArray", () => {
   test("should add an element in the correct position", () => {
     orderedArray.add({ id: 4, rowIndex: 15, name: "Dave" })
     const array = orderedArray.getArray()
-    
+
     expect(array.length).toBe(4)
     expect(array[0].rowIndex).toBe(10)
     expect(array[1].rowIndex).toBe(15)
@@ -54,12 +54,12 @@ describe("OrderedArray", () => {
     const descendingArray = new OrderedArray(
       [...items],
       (item) => item.rowIndex,
-      true
+      true,
     )
-    
+
     descendingArray.add({ id: 4, rowIndex: 15, name: "Dave" })
     const array = descendingArray.getArray()
-    
+
     expect(array.length).toBe(4)
     expect(array[0].rowIndex).toBe(30)
     expect(array[1].rowIndex).toBe(20)
@@ -70,34 +70,52 @@ describe("OrderedArray", () => {
   test("should remove an element by id", () => {
     orderedArray.remove(2) // remove Bob
     const array = orderedArray.getArray()
-    
+
     expect(array.length).toBe(2)
     expect(array[0].name).toBe("Alice")
     expect(array[1].name).toBe("Charlie")
+  })
+
+  test("should handle removing a non-existent id gracefully", () => {
+    const arrayBefore = orderedArray.getArray()
+    orderedArray.remove(999) // non-existent id
+    const arrayAfter = orderedArray.getArray()
+
+    expect(arrayAfter.length).toBe(arrayBefore.length)
+    expect(arrayAfter).toEqual(arrayBefore)
   })
 
   test("should update an element and maintain correct order", () => {
     // Update Bob's rowIndex to 5
     orderedArray.update(2, { rowIndex: 5 })
     const array = orderedArray.getArray()
-    
+
     expect(array.length).toBe(3)
     expect(array[0].name).toBe("Bob") // Bob should now be first
     expect(array[1].name).toBe("Alice")
     expect(array[2].name).toBe("Charlie")
   })
 
+  test("should handle updating a non-existent id gracefully", () => {
+    const arrayBefore = orderedArray.getArray()
+    orderedArray.update(999, { name: "NonExistent" })
+    const arrayAfter = orderedArray.getArray()
+
+    expect(arrayAfter.length).toBe(arrayBefore.length)
+    expect(arrayAfter).toEqual(arrayBefore)
+  })
+
   test("should update an element and maintain correct descending order", () => {
     const descendingArray = new OrderedArray(
       [...items],
       (item) => item.rowIndex,
-      true
+      true,
     )
-    
+
     // Update Bob's rowIndex to 5
     descendingArray.update(2, { rowIndex: 5 })
     const array = descendingArray.getArray()
-    
+
     expect(array.length).toBe(3)
     expect(array[0].name).toBe("Charlie")
     expect(array[1].name).toBe("Alice")
@@ -108,11 +126,11 @@ describe("OrderedArray", () => {
     // Add element with same rowIndex but different id
     orderedArray.add({ id: 4, rowIndex: 20, name: "David" })
     const array = orderedArray.getArray()
-    
+
     // Check that elements with same rowIndex are ordered by id
-    const indexOfBob = array.findIndex(item => item.name === "Bob")
-    const indexOfDavid = array.findIndex(item => item.name === "David")
-    
+    const indexOfBob = array.findIndex((item) => item.name === "Bob")
+    const indexOfDavid = array.findIndex((item) => item.name === "David")
+
     expect(array.length).toBe(4)
     // Bob (id: 2) should come before David (id: 4) since both have rowIndex 20
     expect(indexOfBob).toBeLessThan(indexOfDavid)
@@ -121,7 +139,7 @@ describe("OrderedArray", () => {
   test("should handle empty array", () => {
     const emptyArray = new OrderedArray<TestItem>([], (item) => item.rowIndex)
     expect(emptyArray.getArray().length).toBe(0)
-    
+
     // Add an element to empty array
     emptyArray.add({ id: 1, rowIndex: 10, name: "Alice" })
     expect(emptyArray.getArray().length).toBe(1)
@@ -135,9 +153,9 @@ describe("OrderedArray", () => {
     orderedArray.add({ id: 5, rowIndex: 40, name: "Last" })
     // Add in middle
     orderedArray.add({ id: 6, rowIndex: 25, name: "Middle" })
-    
+
     const array = orderedArray.getArray()
-    
+
     expect(array.length).toBe(6)
     expect(array[0].name).toBe("First")
     expect(array[1].name).toBe("Alice")
@@ -152,24 +170,133 @@ describe("OrderedArray", () => {
     const bob = orderedArray.get(2)
     const charlie = orderedArray.get(3)
     const nonExistent = orderedArray.get(999)
-    
+
     expect(alice).toBeDefined()
     expect(alice?.name).toBe("Alice")
     expect(bob?.name).toBe("Bob")
     expect(charlie?.name).toBe("Charlie")
     expect(nonExistent).toBeUndefined()
-    
+
     // Test that the map is updated after add/remove/update operations
     orderedArray.add({ id: 4, rowIndex: 15, name: "Dave" })
     const dave = orderedArray.get(4)
     expect(dave?.name).toBe("Dave")
-    
+
     orderedArray.update(2, { name: "Bobby" })
     const bobby = orderedArray.get(2)
     expect(bobby?.name).toBe("Bobby")
-    
+
     orderedArray.remove(1) // Remove Alice
     const aliceAfterRemove = orderedArray.get(1)
     expect(aliceAfterRemove).toBeUndefined()
+  })
+
+  test("should maintain lookupMap consistency with array after multiple operations", () => {
+    // Perform a series of operations
+    orderedArray.add({ id: 4, rowIndex: 15, name: "Dave" })
+    orderedArray.add({ id: 5, rowIndex: 25, name: "Eve" })
+    orderedArray.remove(1) // Remove Alice
+    orderedArray.update(3, { rowIndex: 5 }) // Move Charlie to front
+    orderedArray.update(4, { name: "David" }) // Rename Dave without changing position
+
+    // Check lookupMap integrity
+    const array = orderedArray.getArray()
+
+    // Verify every element in the array is retrievable by ID
+    for (const item of array) {
+      const retrieved = orderedArray.get(item.id)
+      expect(retrieved).toBe(item) // Should be the exact same object reference
+    }
+
+    // Verify removed elements are not in the lookupMap
+    expect(orderedArray.get(1)).toBeUndefined()
+  })
+
+  test("should handle duplicate IDs correctly", () => {
+    // This test is important because in a real application, accidental duplicate IDs could happen
+    const dubItems = [
+      { id: 1, rowIndex: 10, name: "Alice" },
+      { id: 2, rowIndex: 20, name: "Bob" },
+      { id: 2, rowIndex: 30, name: "Duplicate Bob" }, // Duplicate ID
+    ]
+
+    // The class should use the last item with a given ID in the lookupMap
+    const dubArray = new OrderedArray(dubItems, (item) => item.rowIndex)
+
+    // Verify the lookupMap has the last item with ID 2
+    expect(dubArray.get(2)?.name).toBe("Duplicate Bob")
+    expect(dubArray.getArray().length).toBe(3) // All items should still be in the array
+
+    // When removing by ID, it should remove the item referenced in the lookupMap
+    const beforeRemoveArray = [...dubArray.getArray()]
+    dubArray.remove(2)
+
+    // The array after removal should have one less item
+    expect(dubArray.getArray().length).toBe(2)
+
+    // Count how many items with id=2 are left (should be 0 or 1 depending on implementation)
+    const remainingItemsWithId2 = dubArray
+      .getArray()
+      .filter((item) => item.id === 2).length
+    // We expect at most one item with id=2 to remain
+    expect(remainingItemsWithId2).toBeLessThanOrEqual(1)
+
+    // Check that lookupMap no longer has id=2
+    expect(dubArray.get(2)).toBeUndefined()
+  })
+
+  test("should handle string keys correctly", () => {
+    interface StringKeyItem {
+      id: number
+      category: string
+      name: string
+    }
+
+    const stringItems: StringKeyItem[] = [
+      { id: 1, category: "C", name: "First" },
+      { id: 2, category: "A", name: "Second" },
+      { id: 3, category: "B", name: "Third" },
+    ]
+
+    const stringKeyArray = new OrderedArray<StringKeyItem, string>(
+      stringItems,
+      (item) => item.category,
+    )
+
+    const sorted = stringKeyArray.getArray()
+    expect(sorted[0].category).toBe("A")
+    expect(sorted[1].category).toBe("B")
+    expect(sorted[2].category).toBe("C")
+  })
+
+  test("should update the lookupMap correctly when updating ID", () => {
+    // Edge case: what if we update the ID itself?
+    // First add an item
+    orderedArray.add({ id: 4, rowIndex: 15, name: "Dave" })
+
+    // Then update its ID (this is a bit of an edge case since IDs are usually immutable)
+    // We're creating a new object with a different ID but same content otherwise
+    const updatedDave = { id: 5, rowIndex: 15, name: "Dave" }
+    orderedArray.remove(4) // Remove by old ID
+    orderedArray.add(updatedDave) // Add with new ID
+
+    // Should be able to find by new ID
+    expect(orderedArray.get(5)?.name).toBe("Dave")
+    // Old ID should be gone
+    expect(orderedArray.get(4)).toBeUndefined()
+  })
+
+  test("should handle updates that don't change order", () => {
+    // Update that doesn't affect sort order
+    orderedArray.update(2, { name: "Bobby" })
+    const array = orderedArray.getArray()
+
+    expect(array.length).toBe(3)
+    expect(array[0].name).toBe("Alice")
+    expect(array[1].name).toBe("Bobby") // Name changed but position same
+    expect(array[2].name).toBe("Charlie")
+
+    // Lookup should work
+    expect(orderedArray.get(2)?.name).toBe("Bobby")
   })
 })

--- a/app/src/helpers/OrderedArray.test.ts
+++ b/app/src/helpers/OrderedArray.test.ts
@@ -228,7 +228,6 @@ describe("OrderedArray", () => {
     expect(dubArray.getArray().length).toBe(3) // All items should still be in the array
 
     // When removing by ID, it should remove the item referenced in the lookupMap
-    const beforeRemoveArray = [...dubArray.getArray()]
     dubArray.remove(2)
 
     // The array after removal should have one less item

--- a/app/src/helpers/OrderedArray.ts
+++ b/app/src/helpers/OrderedArray.ts
@@ -1,5 +1,5 @@
 import { makeObservable, observable } from "mobx"
-import { createModelSchema, list, map, primitive } from "serializr"
+import { createModelSchema, list, mapAsArray, primitive } from "serializr"
 import { pojo } from "./pojo"
 
 /**
@@ -30,7 +30,7 @@ export class OrderedArray<
     })
   }
 
-  getArray(): ReadonlyArray<T> {
+  getArray(): readonly T[] {
     return this.array
   }
 
@@ -147,5 +147,5 @@ export class OrderedArray<
 createModelSchema(OrderedArray, {
   array: list(pojo),
   descending: primitive(),
-  lookupMap: map(pojo),
+  lookupMap: mapAsArray(pojo, "id"),
 })

--- a/app/src/helpers/OrderedArray.ts
+++ b/app/src/helpers/OrderedArray.ts
@@ -1,0 +1,144 @@
+import { makeObservable, observable } from "mobx"
+
+/**
+ * A class that efficiently maintains array order using a key extractor
+ */
+export class OrderedArray<
+  T extends { id: number },
+  K extends number | string = number,
+> {
+  readonly array: T[]
+  private keyExtractor: (item: T) => K
+  private descending: boolean
+  private idToIndexMap: Map<number, number>
+
+  constructor(
+    array: T[],
+    keyExtractor: (item: T) => K,
+    descending: boolean = false,
+  ) {
+    this.array = array
+    this.keyExtractor = keyExtractor
+    this.descending = descending
+    this.idToIndexMap = new Map()
+    this.sort()
+    this.updateIdToIndexMap()
+
+    makeObservable(this, {
+      array: observable.shallow,
+    })
+  }
+
+  getArray(): T[] {
+    return this.array
+  }
+
+  /**
+   * Get an element by its id in O(1) time
+   */
+  get(id: number): T | undefined {
+    const index = this.idToIndexMap.get(id)
+    return index !== undefined ? this.array[index] : undefined
+  }
+
+  private updateIdToIndexMap(): void {
+    this.idToIndexMap.clear()
+    for (let i = 0; i < this.array.length; i++) {
+      this.idToIndexMap.set(this.array[i].id, i)
+    }
+  }
+
+  private findInsertionIndex(element: T): number {
+    const elementKey = this.keyExtractor(element)
+    let low = 0
+    let high = this.array.length - 1
+
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2)
+      const midKey = this.keyExtractor(this.array[mid])
+
+      let comparison: number
+      if (elementKey < midKey) {
+        comparison = -1
+      } else if (elementKey > midKey) {
+        comparison = 1
+      } else {
+        comparison = 0
+      }
+
+      if (this.descending) {
+        comparison = -comparison
+      }
+
+      if (comparison < 0) {
+        high = mid - 1
+      } else if (comparison > 0) {
+        low = mid + 1
+      } else {
+        if ("id" in element && "id" in this.array[mid]) {
+          const idComparison = element.id - this.array[mid].id
+          if (idComparison < 0) {
+            high = mid - 1
+          } else if (idComparison > 0) {
+            low = mid + 1
+          } else {
+            return mid
+          }
+        } else {
+          return mid
+        }
+      }
+    }
+
+    return low
+  }
+
+  add(element: T): T[] {
+    const insertionIndex = this.findInsertionIndex(element)
+    this.array.splice(insertionIndex, 0, element)
+    this.updateIdToIndexMap()
+    return this.array
+  }
+
+  remove(id: number): T[] {
+    const index = this.idToIndexMap.get(id)
+    if (index !== undefined) {
+      this.array.splice(index, 1)
+      this.updateIdToIndexMap()
+    }
+    return this.array
+  }
+
+  update(id: number, updatedElement: Partial<T>): T[] {
+    const index = this.idToIndexMap.get(id)
+    if (index !== undefined) {
+      const originalElement = this.array[index]
+      this.array.splice(index, 1)
+
+      const updatedItem = { ...originalElement, ...updatedElement } as T
+
+      const newIndex = this.findInsertionIndex(updatedItem)
+      this.array.splice(newIndex, 0, updatedItem)
+      this.updateIdToIndexMap()
+    }
+    return this.array
+  }
+
+  private sort(): void {
+    this.array.sort((a, b) => {
+      const keyA = this.keyExtractor(a)
+      const keyB = this.keyExtractor(b)
+
+      let comparison: number
+      if (keyA < keyB) {
+        comparison = -1
+      } else if (keyA > keyB) {
+        comparison = 1
+      } else {
+        comparison = a.id - b.id
+      }
+
+      return this.descending ? -comparison : comparison
+    })
+  }
+}

--- a/app/src/helpers/OrderedArray.ts
+++ b/app/src/helpers/OrderedArray.ts
@@ -1,4 +1,6 @@
 import { makeObservable, observable } from "mobx"
+import { createModelSchema, list, map, primitive } from "serializr"
+import { pojo } from "./pojo"
 
 /**
  * A class that efficiently maintains array order using a key extractor
@@ -142,3 +144,9 @@ export class OrderedArray<
     })
   }
 }
+
+createModelSchema(OrderedArray, {
+  array: list(pojo),
+  descending: primitive(),
+  idToIndexMap: map(pojo),
+})

--- a/app/src/helpers/TickOrderedArray.ts
+++ b/app/src/helpers/TickOrderedArray.ts
@@ -1,0 +1,12 @@
+import { createModelSchema } from "serializr"
+import { OrderedArray } from "./OrderedArray"
+
+export class TickOrderedArray<
+  T extends { id: number; tick: number },
+> extends OrderedArray<T, number> {
+  constructor(array: T[] = [], descending: boolean = false) {
+    super(array, (item) => (item as any).tick, descending)
+  }
+}
+
+createModelSchema(TickOrderedArray, {})

--- a/app/src/helpers/toRawEvents.ts
+++ b/app/src/helpers/toRawEvents.ts
@@ -30,7 +30,7 @@ const fromSignalEvent = (e: TrackEvent): TrackEvent => {
   return e
 }
 
-export function toRawEvents(events: TrackEvent[]): AnyEvent[] {
+export function toRawEvents(events: readonly TrackEvent[]): AnyEvent[] {
   const a = flatten(events.map(fromSignalEvent).map(deassembleNote))
   const c = addDeltaTime(a)
   return c as AnyEvent[]

--- a/app/src/midi/midiConversion.ts
+++ b/app/src/midi/midiConversion.ts
@@ -8,7 +8,6 @@ import {
   StreamSource,
   write as writeMidiFile,
 } from "midifile-ts"
-import { toJS } from "mobx"
 import { isNotNull } from "../helpers/array"
 import { downloadBlob } from "../helpers/Downloader"
 import { addDeltaTime, toRawEvents } from "../helpers/toRawEvents"
@@ -143,7 +142,7 @@ const setChannel =
   }
 
 export function songToMidiEvents(song: Song): AnyEvent[][] {
-  const tracks = toJS(song.tracks)
+  const tracks = song.tracks
   return tracks.map((t) => {
     const endOfTrack: EndOfTrackEvent = {
       deltaTime: 0,

--- a/app/src/player/collectAllEvents.ts
+++ b/app/src/player/collectAllEvents.ts
@@ -4,7 +4,7 @@ import { deassemble as deassembleNote } from "../helpers/noteAssembler"
 import Track, { TrackEvent, TrackId } from "../track"
 
 export const convertTrackEvents = (
-  events: TrackEvent[],
+  events: readonly TrackEvent[],
   channel: number | undefined,
   trackId: TrackId,
 ) =>
@@ -20,5 +20,5 @@ export const convertTrackEvents = (
         }) as PlayerEventOf<AnyChannelEvent>,
     )
 
-export const collectAllEvents = (tracks: Track[]): PlayerEvent[] =>
+export const collectAllEvents = (tracks: readonly Track[]): PlayerEvent[] =>
   tracks.flatMap((t) => convertTrackEvents(t.events, t.channel, t.id))

--- a/app/src/song/Song.ts
+++ b/app/src/song/Song.ts
@@ -3,7 +3,7 @@ import { action, computed, makeObservable, observable, reaction } from "mobx"
 import { createModelSchema, list, object, primitive } from "serializr"
 import { Measure } from "../entities/measure/Measure"
 import { NoteNumber } from "../entities/unit/NoteNumber"
-import { isNotNull, isNotUndefined } from "../helpers/array"
+import { isNotNull } from "../helpers/array"
 import { collectAllEvents } from "../player/collectAllEvents"
 import Track, { isNoteEvent, isTimeSignatureEvent, TrackId } from "../track"
 
@@ -99,10 +99,12 @@ export default class Song {
   }
 
   get endOfSong(): number {
-    const eos = Math.max(
-      ...this.tracks.map((t) => t.endOfTrack).filter(isNotUndefined),
-    )
+    const eos = Math.max(...this.tracks.map((t) => t.endOfTrack))
     return (eos ?? 0) + END_MARGIN
+  }
+
+  updateEndOfSong() {
+    this.tracks.forEach((t) => t.updateEndOfTrack())
   }
 
   get allEvents(): PlayerEvent[] {

--- a/app/src/track/Track.test.ts
+++ b/app/src/track/Track.test.ts
@@ -22,7 +22,7 @@ describe("Track", () => {
     expect(t.events.length).toBe(1)
     expect(t.events[0].tick).toBe(123)
   })
-  it("should reset end of track after note deletion", () => {
+  it("endOfTrack() should reset end of track after note deletion", () => {
     const track = emptyTrack(5)
     const noteEvent = track.addEvent<NoteEvent>({
       type: "channel",
@@ -34,6 +34,7 @@ describe("Track", () => {
     })
     expect(track.endOfTrack).toBe(243)
     track.removeEvent(noteEvent.id)
+    track.updateEndOfTrack()
     expect(track.endOfTrack).toBe(0)
   })
 })

--- a/app/src/track/Track.ts
+++ b/app/src/track/Track.ts
@@ -82,6 +82,7 @@ export default class Track {
       return null
     }
     this._events.update(id, newObj)
+    this.extendEndOfTrack(newObj)
 
     if (process.env.NODE_ENV !== "production") {
       validateMidiEvent(newObj)

--- a/app/src/track/Track.ts
+++ b/app/src/track/Track.ts
@@ -81,7 +81,7 @@ export default class Track {
     if (isEqual(newObj, anObj)) {
       return null
     }
-    this.events[index] = newObj
+    this._events.update(id, newObj)
 
     if (process.env.NODE_ENV !== "production") {
       validateMidiEvent(newObj)

--- a/app/src/track/Track.ts
+++ b/app/src/track/Track.ts
@@ -7,10 +7,9 @@ import {
   TrackNameEvent,
 } from "midifile-ts"
 import { action, computed, makeObservable, observable, transaction } from "mobx"
-import { createModelSchema, list, primitive } from "serializr"
+import { createModelSchema, object, primitive } from "serializr"
 import { bpmToUSecPerBeat } from "../helpers/bpm"
-import { OrderedArray } from "../helpers/OrderedArray"
-import { pojo } from "../helpers/pojo"
+import { TickOrderedArray } from "../helpers/TickOrderedArray"
 import {
   programChangeMidiEvent,
   setTempoMidiEvent,
@@ -39,7 +38,7 @@ export const UNASSIGNED_TRACK_ID = -1 as TrackId
 
 export default class Track {
   id: TrackId = UNASSIGNED_TRACK_ID
-  private readonly _events: OrderedArray<TrackEvent, number>
+  private readonly _events = new TickOrderedArray<TrackEvent>()
   endOfTrack: number = 0
   channel: number | undefined = undefined
 
@@ -48,12 +47,6 @@ export default class Track {
   getEventById = (id: number): TrackEvent | undefined => this._events.get(id)
 
   constructor() {
-    this._events = new OrderedArray<TrackEvent, number>(
-      [],
-      (e) => e.tick,
-      false,
-    )
-
     makeObservable(this, {
       updateEvent: action,
       updateEvents: action,
@@ -332,7 +325,7 @@ export default class Track {
 
 createModelSchema(Track, {
   id: primitive(),
-  events: list(pojo),
+  _events: object(TickOrderedArray),
   lastEventId: primitive(),
   channel: primitive(),
 })

--- a/app/src/track/Track.ts
+++ b/app/src/track/Track.ts
@@ -66,7 +66,7 @@ export default class Track {
     })
   }
 
-  get events(): TrackEvent[] {
+  get events(): readonly TrackEvent[] {
     return this._events.getArray()
   }
 

--- a/app/src/track/Track.ts
+++ b/app/src/track/Track.ts
@@ -123,7 +123,7 @@ export default class Track {
       id: this.lastEventId++,
     } as T
     this._events.add(newEvent)
-    this.updateEndOfTrack(newEvent)
+    this.extendEndOfTrack(newEvent)
     return newEvent
   }
 
@@ -187,7 +187,17 @@ export default class Track {
     )
   }
 
-  private updateEndOfTrack(newEvent: TrackEvent) {
+  updateEndOfTrack() {
+    let maxTick = 0
+    // Use for loop instead of map/filter to avoid the error `Maximum call stack size exceeded`
+    for (const e of this.events) {
+      const tick = isNoteEvent(e) ? e.tick + e.duration : e.tick
+      maxTick = Math.max(maxTick, tick)
+    }
+    this.endOfTrack = maxTick
+  }
+
+  private extendEndOfTrack(newEvent: TrackEvent) {
     if (isNoteEvent(newEvent)) {
       this.endOfTrack = Math.max(
         this.endOfTrack,
@@ -328,4 +338,5 @@ createModelSchema(Track, {
   _events: object(TickOrderedArray),
   lastEventId: primitive(),
   channel: primitive(),
+  endOfTrack: primitive(),
 })

--- a/app/src/track/selector.ts
+++ b/app/src/track/selector.ts
@@ -24,29 +24,31 @@ export const isTickBefore =
   <T extends { tick: number }>(e: T) =>
     e.tick <= tick
 
-export const getVolume = (events: TrackEvent[], tick: number) =>
+export const getVolume = (events: readonly TrackEvent[], tick: number) =>
   getLast(events.filter(isVolumeEvent).filter(isTickBefore(tick)))?.value
 
-export const getPan = (events: TrackEvent[], tick: number) =>
+export const getPan = (events: readonly TrackEvent[], tick: number) =>
   getLast(events.filter(isPanEvent).filter(isTickBefore(tick)))?.value
 
-export const getTrackNameEvent = (events: TrackEvent[]) =>
+export const getTrackNameEvent = (events: readonly TrackEvent[]) =>
   getLast(events.filter(isTrackNameEvent))
 
-export const getTempoEvent = (events: TrackEvent[], tick: number) =>
+export const getTempoEvent = (events: readonly TrackEvent[], tick: number) =>
   getLast(events.filter(isSetTempoEvent).filter(isTickBefore(tick)))
 
-export const getTimeSignatureEvent = (events: TrackEvent[], tick: number) =>
-  getLast(events.filter(isTimeSignatureEvent).filter(isTickBefore(tick)))
+export const getTimeSignatureEvent = (
+  events: readonly TrackEvent[],
+  tick: number,
+) => getLast(events.filter(isTimeSignatureEvent).filter(isTickBefore(tick)))
 
-export const getProgramNumberEvent = (events: TrackEvent[]) =>
+export const getProgramNumberEvent = (events: readonly TrackEvent[]) =>
   getLast(events.filter(isProgramChangeEvent))
 
-export const getEndOfTrackEvent = (events: TrackEvent[]) =>
+export const getEndOfTrackEvent = (events: readonly TrackEvent[]) =>
   getLast(events.filter(isEndOfTrackEvent))
 
 export const getTempo = (
-  events: TrackEvent[],
+  events: readonly TrackEvent[],
   tick: number,
 ): number | undefined => {
   const e = getTempoEvent(events, tick)
@@ -57,7 +59,10 @@ export const getTempo = (
 }
 
 // collect events which will be retained in the synthesizer
-export const getStatusEvents = (events: TrackEvent[], tick: number) => {
+export const getStatusEvents = (
+  events: readonly TrackEvent[],
+  tick: number,
+) => {
   const controlEvents = events
     .filter(isControllerEvent)
     .filter(isTickBefore(tick))

--- a/packages/community/src/services/EventSource.ts
+++ b/packages/community/src/services/EventSource.ts
@@ -66,7 +66,7 @@ export const isTickBefore =
     e.tick <= tick
 
 // collect events which will be retained in the synthesizer
-const getStatusEvents = (events: TrackEvent[], tick: number) => {
+const getStatusEvents = (events: readonly TrackEvent[], tick: number) => {
   const controlEvents = events
     .filter(isControllerEvent)
     .filter(isTickBefore(tick))

--- a/packages/community/src/song/Song.ts
+++ b/packages/community/src/song/Song.ts
@@ -10,7 +10,7 @@ export type TrackEventOf<T> = DistributiveOmit<T, "deltaTime"> & {
 export type TrackEvent = TrackEventOf<AnyEvent>
 
 export interface Track {
-  events: TrackEvent[]
+  events: readonly TrackEvent[]
   endOfTrack: number
 }
 

--- a/packages/community/src/track/Track.ts
+++ b/packages/community/src/track/Track.ts
@@ -9,10 +9,10 @@ export type TrackEventOf<T> = DistributiveOmit<T, "deltaTime"> & {
 export type TrackEvent = TrackEventOf<AnyEvent>
 
 export interface Track {
-  events: TrackEvent[]
+  events: readonly TrackEvent[]
   endOfTrack: number
 }
 
-export function getEndOfTrack(events: TrackEvent[]) {
+export function getEndOfTrack(events: readonly TrackEvent[]) {
   return max(events.map((event) => event.tick)) ?? 0
 }


### PR DESCRIPTION
## `Track.endOfTrack`

The endOfTrack, which is the length of the track, was calculated based on the position of the last note, but it was very heavy when dragging notes in a long song because it is an O(N) that scans the entire case. We decided to calculate endOfTrack only when adding/updating notes and not shortening it. endOfTrack is recalculated on WAV export and updated to the shortest possible time.

## `OrderedArray`

The order of track.events was sorted based on ticks. However, the sorting was frequently called when adding or updating events, making it very slow. Therefore, we implemented OrderedArray, which preserves the order of the events and performs additions and updates. In addition, since the process of retrieving events by id was inefficient and resulted in O(N) at worst, we made it possible to retrieve events at high speed by managing a map with the id as the key.

ref #423
